### PR TITLE
feat: Mutate function now accepts arguments

### DIFF
--- a/.changeset/purple-plants-mix.md
+++ b/.changeset/purple-plants-mix.md
@@ -1,0 +1,5 @@
+---
+'@harnessio/oats-plugin-react-query': minor
+---
+
+Mutate function now accepts arguments

--- a/examples/output/petstore-openapi-v3.0/hooks/useAddPetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useAddPetMutation.ts
@@ -24,15 +24,21 @@ export function addPet(props: AddPetProps): Promise<AddPetOkResponse> {
 	});
 }
 
+export type AddPetMutationProps<T extends keyof AddPetProps> = Omit<AddPetProps, T> &
+	Partial<Pick<AddPetProps, T>>;
+
 /**
  * Add a new pet to the store
  */
-export function useAddPetMutation(
-	props: AddPetProps,
+export function useAddPetMutation<T extends keyof AddPetProps>(
+	props: Pick<Partial<AddPetProps>, T>,
 	options?: Omit<
-		UseMutationOptions<AddPetOkResponse, AddPetErrorResponse>,
+		UseMutationOptions<AddPetOkResponse, AddPetErrorResponse, AddPetMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<AddPetOkResponse, AddPetErrorResponse>(() => addPet(props), options);
+	return useMutation<AddPetOkResponse, AddPetErrorResponse, AddPetMutationProps<T>>(
+		(mutateProps: AddPetMutationProps<T>) => addPet({ ...props, ...mutateProps } as AddPetProps),
+		options,
+	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useCreateUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useCreateUserMutation.ts
@@ -25,18 +25,22 @@ export function createUser(props: CreateUserProps): Promise<CreateUserOkResponse
 	});
 }
 
+export type CreateUserMutationProps<T extends keyof CreateUserProps> = Omit<CreateUserProps, T> &
+	Partial<Pick<CreateUserProps, T>>;
+
 /**
  * This can only be done by the logged in user.
  */
-export function useCreateUserMutation(
-	props: CreateUserProps,
+export function useCreateUserMutation<T extends keyof CreateUserProps>(
+	props: Pick<Partial<CreateUserProps>, T>,
 	options?: Omit<
-		UseMutationOptions<CreateUserOkResponse, CreateUserErrorResponse>,
+		UseMutationOptions<CreateUserOkResponse, CreateUserErrorResponse, CreateUserMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<CreateUserOkResponse, CreateUserErrorResponse>(
-		() => createUser(props),
+	return useMutation<CreateUserOkResponse, CreateUserErrorResponse, CreateUserMutationProps<T>>(
+		(mutateProps: CreateUserMutationProps<T>) =>
+			createUser({ ...props, ...mutateProps } as CreateUserProps),
 		options,
 	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useCreateUsersWithListInputMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useCreateUsersWithListInputMutation.ts
@@ -27,18 +27,30 @@ export function createUsersWithListInput(
 	});
 }
 
+export type CreateUsersWithListInputMutationProps<T extends keyof CreateUsersWithListInputProps> =
+	Omit<CreateUsersWithListInputProps, T> & Partial<Pick<CreateUsersWithListInputProps, T>>;
+
 /**
  * Creates list of users with given input array
  */
-export function useCreateUsersWithListInputMutation(
-	props: CreateUsersWithListInputProps,
+export function useCreateUsersWithListInputMutation<T extends keyof CreateUsersWithListInputProps>(
+	props: Pick<Partial<CreateUsersWithListInputProps>, T>,
 	options?: Omit<
-		UseMutationOptions<CreateUsersWithListInputOkResponse, CreateUsersWithListInputErrorResponse>,
+		UseMutationOptions<
+			CreateUsersWithListInputOkResponse,
+			CreateUsersWithListInputErrorResponse,
+			CreateUsersWithListInputMutationProps<T>
+		>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<CreateUsersWithListInputOkResponse, CreateUsersWithListInputErrorResponse>(
-		() => createUsersWithListInput(props),
+	return useMutation<
+		CreateUsersWithListInputOkResponse,
+		CreateUsersWithListInputErrorResponse,
+		CreateUsersWithListInputMutationProps<T>
+	>(
+		(mutateProps: CreateUsersWithListInputMutationProps<T>) =>
+			createUsersWithListInput({ ...props, ...mutateProps } as CreateUsersWithListInputProps),
 		options,
 	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeleteOrderMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeleteOrderMutation.ts
@@ -28,18 +28,26 @@ export function deleteOrder(props: DeleteOrderProps): Promise<DeleteOrderOkRespo
 	});
 }
 
+export type DeleteOrderMutationProps<T extends keyof DeleteOrderProps> = Omit<DeleteOrderProps, T> &
+	Partial<Pick<DeleteOrderProps, T>>;
+
 /**
  * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
  */
-export function useDeleteOrderMutation(
-	props: DeleteOrderProps,
+export function useDeleteOrderMutation<T extends keyof DeleteOrderProps>(
+	props: Pick<Partial<DeleteOrderProps>, T>,
 	options?: Omit<
-		UseMutationOptions<DeleteOrderOkResponse, DeleteOrderErrorResponse>,
+		UseMutationOptions<
+			DeleteOrderOkResponse,
+			DeleteOrderErrorResponse,
+			DeleteOrderMutationProps<T>
+		>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<DeleteOrderOkResponse, DeleteOrderErrorResponse>(
-		() => deleteOrder(props),
+	return useMutation<DeleteOrderOkResponse, DeleteOrderErrorResponse, DeleteOrderMutationProps<T>>(
+		(mutateProps: DeleteOrderMutationProps<T>) =>
+			deleteOrder({ ...props, ...mutateProps } as DeleteOrderProps),
 		options,
 	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
@@ -28,15 +28,22 @@ export function deletePet(props: DeletePetProps): Promise<DeletePetOkResponse> {
 	});
 }
 
+export type DeletePetMutationProps<T extends keyof DeletePetProps> = Omit<DeletePetProps, T> &
+	Partial<Pick<DeletePetProps, T>>;
+
 /**
  *
  */
-export function useDeletePetMutation(
-	props: DeletePetProps,
+export function useDeletePetMutation<T extends keyof DeletePetProps>(
+	props: Pick<Partial<DeletePetProps>, T>,
 	options?: Omit<
-		UseMutationOptions<DeletePetOkResponse, DeletePetErrorResponse>,
+		UseMutationOptions<DeletePetOkResponse, DeletePetErrorResponse, DeletePetMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<DeletePetOkResponse, DeletePetErrorResponse>(() => deletePet(props), options);
+	return useMutation<DeletePetOkResponse, DeletePetErrorResponse, DeletePetMutationProps<T>>(
+		(mutateProps: DeletePetMutationProps<T>) =>
+			deletePet({ ...props, ...mutateProps } as DeletePetProps),
+		options,
+	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeleteUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeleteUserMutation.ts
@@ -25,18 +25,22 @@ export function deleteUser(props: DeleteUserProps): Promise<DeleteUserOkResponse
 	});
 }
 
+export type DeleteUserMutationProps<T extends keyof DeleteUserProps> = Omit<DeleteUserProps, T> &
+	Partial<Pick<DeleteUserProps, T>>;
+
 /**
  * This can only be done by the logged in user.
  */
-export function useDeleteUserMutation(
-	props: DeleteUserProps,
+export function useDeleteUserMutation<T extends keyof DeleteUserProps>(
+	props: Pick<Partial<DeleteUserProps>, T>,
 	options?: Omit<
-		UseMutationOptions<DeleteUserOkResponse, DeleteUserErrorResponse>,
+		UseMutationOptions<DeleteUserOkResponse, DeleteUserErrorResponse, DeleteUserMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<DeleteUserOkResponse, DeleteUserErrorResponse>(
-		() => deleteUser(props),
+	return useMutation<DeleteUserOkResponse, DeleteUserErrorResponse, DeleteUserMutationProps<T>>(
+		(mutateProps: DeleteUserMutationProps<T>) =>
+			deleteUser({ ...props, ...mutateProps } as DeleteUserProps),
 		options,
 	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/usePlaceOrderMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/usePlaceOrderMutation.ts
@@ -25,18 +25,22 @@ export function placeOrder(props: PlaceOrderProps): Promise<PlaceOrderOkResponse
 	});
 }
 
+export type PlaceOrderMutationProps<T extends keyof PlaceOrderProps> = Omit<PlaceOrderProps, T> &
+	Partial<Pick<PlaceOrderProps, T>>;
+
 /**
  * Place a new order in the store
  */
-export function usePlaceOrderMutation(
-	props: PlaceOrderProps,
+export function usePlaceOrderMutation<T extends keyof PlaceOrderProps>(
+	props: Pick<Partial<PlaceOrderProps>, T>,
 	options?: Omit<
-		UseMutationOptions<PlaceOrderOkResponse, PlaceOrderErrorResponse>,
+		UseMutationOptions<PlaceOrderOkResponse, PlaceOrderErrorResponse, PlaceOrderMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<PlaceOrderOkResponse, PlaceOrderErrorResponse>(
-		() => placeOrder(props),
+	return useMutation<PlaceOrderOkResponse, PlaceOrderErrorResponse, PlaceOrderMutationProps<T>>(
+		(mutateProps: PlaceOrderMutationProps<T>) =>
+			placeOrder({ ...props, ...mutateProps } as PlaceOrderProps),
 		options,
 	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetMutation.ts
@@ -24,15 +24,22 @@ export function updatePet(props: UpdatePetProps): Promise<UpdatePetOkResponse> {
 	});
 }
 
+export type UpdatePetMutationProps<T extends keyof UpdatePetProps> = Omit<UpdatePetProps, T> &
+	Partial<Pick<UpdatePetProps, T>>;
+
 /**
  * Update an existing pet by Id
  */
-export function useUpdatePetMutation(
-	props: UpdatePetProps,
+export function useUpdatePetMutation<T extends keyof UpdatePetProps>(
+	props: Pick<Partial<UpdatePetProps>, T>,
 	options?: Omit<
-		UseMutationOptions<UpdatePetOkResponse, UpdatePetErrorResponse>,
+		UseMutationOptions<UpdatePetOkResponse, UpdatePetErrorResponse, UpdatePetMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<UpdatePetOkResponse, UpdatePetErrorResponse>(() => updatePet(props), options);
+	return useMutation<UpdatePetOkResponse, UpdatePetErrorResponse, UpdatePetMutationProps<T>>(
+		(mutateProps: UpdatePetMutationProps<T>) =>
+			updatePet({ ...props, ...mutateProps } as UpdatePetProps),
+		options,
+	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetWithFormMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetWithFormMutation.ts
@@ -37,18 +37,33 @@ export function updatePetWithForm(
 	});
 }
 
+export type UpdatePetWithFormMutationProps<T extends keyof UpdatePetWithFormProps> = Omit<
+	UpdatePetWithFormProps,
+	T
+> &
+	Partial<Pick<UpdatePetWithFormProps, T>>;
+
 /**
  *
  */
-export function useUpdatePetWithFormMutation(
-	props: UpdatePetWithFormProps,
+export function useUpdatePetWithFormMutation<T extends keyof UpdatePetWithFormProps>(
+	props: Pick<Partial<UpdatePetWithFormProps>, T>,
 	options?: Omit<
-		UseMutationOptions<UpdatePetWithFormOkResponse, UpdatePetWithFormErrorResponse>,
+		UseMutationOptions<
+			UpdatePetWithFormOkResponse,
+			UpdatePetWithFormErrorResponse,
+			UpdatePetWithFormMutationProps<T>
+		>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<UpdatePetWithFormOkResponse, UpdatePetWithFormErrorResponse>(
-		() => updatePetWithForm(props),
+	return useMutation<
+		UpdatePetWithFormOkResponse,
+		UpdatePetWithFormErrorResponse,
+		UpdatePetWithFormMutationProps<T>
+	>(
+		(mutateProps: UpdatePetWithFormMutationProps<T>) =>
+			updatePetWithForm({ ...props, ...mutateProps } as UpdatePetWithFormProps),
 		options,
 	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdateUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdateUserMutation.ts
@@ -30,18 +30,22 @@ export function updateUser(props: UpdateUserProps): Promise<UpdateUserOkResponse
 	});
 }
 
+export type UpdateUserMutationProps<T extends keyof UpdateUserProps> = Omit<UpdateUserProps, T> &
+	Partial<Pick<UpdateUserProps, T>>;
+
 /**
  * This can only be done by the logged in user.
  */
-export function useUpdateUserMutation(
-	props: UpdateUserProps,
+export function useUpdateUserMutation<T extends keyof UpdateUserProps>(
+	props: Pick<Partial<UpdateUserProps>, T>,
 	options?: Omit<
-		UseMutationOptions<UpdateUserOkResponse, UpdateUserErrorResponse>,
+		UseMutationOptions<UpdateUserOkResponse, UpdateUserErrorResponse, UpdateUserMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<UpdateUserOkResponse, UpdateUserErrorResponse>(
-		() => updateUser(props),
+	return useMutation<UpdateUserOkResponse, UpdateUserErrorResponse, UpdateUserMutationProps<T>>(
+		(mutateProps: UpdateUserMutationProps<T>) =>
+			updateUser({ ...props, ...mutateProps } as UpdateUserProps),
 		options,
 	);
 }

--- a/examples/output/petstore-openapi-v3.0/hooks/useUploadFileMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUploadFileMutation.ts
@@ -38,18 +38,22 @@ export function uploadFile(props: UploadFileProps): Promise<UploadFileOkResponse
 	});
 }
 
+export type UploadFileMutationProps<T extends keyof UploadFileProps> = Omit<UploadFileProps, T> &
+	Partial<Pick<UploadFileProps, T>>;
+
 /**
  *
  */
-export function useUploadFileMutation(
-	props: UploadFileProps,
+export function useUploadFileMutation<T extends keyof UploadFileProps>(
+	props: Pick<Partial<UploadFileProps>, T>,
 	options?: Omit<
-		UseMutationOptions<UploadFileOkResponse, UploadFileErrorResponse>,
+		UseMutationOptions<UploadFileOkResponse, UploadFileErrorResponse, UploadFileMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<UploadFileOkResponse, UploadFileErrorResponse>(
-		() => uploadFile(props),
+	return useMutation<UploadFileOkResponse, UploadFileErrorResponse, UploadFileMutationProps<T>>(
+		(mutateProps: UploadFileMutationProps<T>) =>
+			uploadFile({ ...props, ...mutateProps } as UploadFileProps),
 		options,
 	);
 }

--- a/examples/output/petstore-openapi-v3.0/index.ts
+++ b/examples/output/petstore-openapi-v3.0/index.ts
@@ -1,5 +1,6 @@
 export type {
 	AddPetErrorResponse,
+	AddPetMutationProps,
 	AddPetOkResponse,
 	AddPetProps,
 	AddPetRequestBody,
@@ -7,6 +8,7 @@ export type {
 export { addPet, useAddPetMutation } from './hooks/useAddPetMutation';
 export type {
 	CreateUserErrorResponse,
+	CreateUserMutationProps,
 	CreateUserOkResponse,
 	CreateUserProps,
 	CreateUserRequestBody,
@@ -14,6 +16,7 @@ export type {
 export { createUser, useCreateUserMutation } from './hooks/useCreateUserMutation';
 export type {
 	CreateUsersWithListInputErrorResponse,
+	CreateUsersWithListInputMutationProps,
 	CreateUsersWithListInputOkResponse,
 	CreateUsersWithListInputProps,
 	CreateUsersWithListInputRequestBody,
@@ -25,6 +28,7 @@ export {
 export type {
 	DeleteOrderErrorResponse,
 	DeleteOrderMutationPathParams,
+	DeleteOrderMutationProps,
 	DeleteOrderOkResponse,
 	DeleteOrderProps,
 } from './hooks/useDeleteOrderMutation';
@@ -32,6 +36,7 @@ export { deleteOrder, useDeleteOrderMutation } from './hooks/useDeleteOrderMutat
 export type {
 	DeletePetErrorResponse,
 	DeletePetMutationPathParams,
+	DeletePetMutationProps,
 	DeletePetOkResponse,
 	DeletePetProps,
 } from './hooks/useDeletePetMutation';
@@ -39,6 +44,7 @@ export { deletePet, useDeletePetMutation } from './hooks/useDeletePetMutation';
 export type {
 	DeleteUserErrorResponse,
 	DeleteUserMutationPathParams,
+	DeleteUserMutationProps,
 	DeleteUserOkResponse,
 	DeleteUserProps,
 } from './hooks/useDeleteUserMutation';
@@ -99,6 +105,7 @@ export type {
 export { logoutUser, useLogoutUserQuery } from './hooks/useLogoutUserQuery';
 export type {
 	PlaceOrderErrorResponse,
+	PlaceOrderMutationProps,
 	PlaceOrderOkResponse,
 	PlaceOrderProps,
 	PlaceOrderRequestBody,
@@ -106,6 +113,7 @@ export type {
 export { placeOrder, usePlaceOrderMutation } from './hooks/usePlaceOrderMutation';
 export type {
 	UpdatePetErrorResponse,
+	UpdatePetMutationProps,
 	UpdatePetOkResponse,
 	UpdatePetProps,
 	UpdatePetRequestBody,
@@ -114,6 +122,7 @@ export { updatePet, useUpdatePetMutation } from './hooks/useUpdatePetMutation';
 export type {
 	UpdatePetWithFormErrorResponse,
 	UpdatePetWithFormMutationPathParams,
+	UpdatePetWithFormMutationProps,
 	UpdatePetWithFormMutationQueryParams,
 	UpdatePetWithFormOkResponse,
 	UpdatePetWithFormProps,
@@ -125,6 +134,7 @@ export {
 export type {
 	UpdateUserErrorResponse,
 	UpdateUserMutationPathParams,
+	UpdateUserMutationProps,
 	UpdateUserOkResponse,
 	UpdateUserProps,
 	UpdateUserRequestBody,
@@ -133,6 +143,7 @@ export { updateUser, useUpdateUserMutation } from './hooks/useUpdateUserMutation
 export type {
 	UploadFileErrorResponse,
 	UploadFileMutationPathParams,
+	UploadFileMutationProps,
 	UploadFileMutationQueryParams,
 	UploadFileOkResponse,
 	UploadFileProps,

--- a/examples/output/petstore-swagger/hooks/useAddPetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useAddPetMutation.ts
@@ -25,15 +25,21 @@ export function addPet(props: AddPetProps): Promise<AddPetOkResponse> {
 	});
 }
 
+export type AddPetMutationProps<T extends keyof AddPetProps> = Omit<AddPetProps, T> &
+	Partial<Pick<AddPetProps, T>>;
+
 /**
  *
  */
-export function useAddPetMutation(
-	props: AddPetProps,
+export function useAddPetMutation<T extends keyof AddPetProps>(
+	props: Pick<Partial<AddPetProps>, T>,
 	options?: Omit<
-		UseMutationOptions<AddPetOkResponse, AddPetErrorResponse>,
+		UseMutationOptions<AddPetOkResponse, AddPetErrorResponse, AddPetMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<AddPetOkResponse, AddPetErrorResponse>(() => addPet(props), options);
+	return useMutation<AddPetOkResponse, AddPetErrorResponse, AddPetMutationProps<T>>(
+		(mutateProps: AddPetMutationProps<T>) => addPet({ ...props, ...mutateProps } as AddPetProps),
+		options,
+	);
 }

--- a/examples/output/petstore-swagger/hooks/useCreateUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUserMutation.ts
@@ -26,18 +26,22 @@ export function createUser(props: CreateUserProps): Promise<CreateUserOkResponse
 	});
 }
 
+export type CreateUserMutationProps<T extends keyof CreateUserProps> = Omit<CreateUserProps, T> &
+	Partial<Pick<CreateUserProps, T>>;
+
 /**
  * This can only be done by the logged in user.
  */
-export function useCreateUserMutation(
-	props: CreateUserProps,
+export function useCreateUserMutation<T extends keyof CreateUserProps>(
+	props: Pick<Partial<CreateUserProps>, T>,
 	options?: Omit<
-		UseMutationOptions<CreateUserOkResponse, CreateUserErrorResponse>,
+		UseMutationOptions<CreateUserOkResponse, CreateUserErrorResponse, CreateUserMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<CreateUserOkResponse, CreateUserErrorResponse>(
-		() => createUser(props),
+	return useMutation<CreateUserOkResponse, CreateUserErrorResponse, CreateUserMutationProps<T>>(
+		(mutateProps: CreateUserMutationProps<T>) =>
+			createUser({ ...props, ...mutateProps } as CreateUserProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/hooks/useCreateUsersWithArrayInputMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUsersWithArrayInputMutation.ts
@@ -32,18 +32,32 @@ export function createUsersWithArrayInput(
 	});
 }
 
+export type CreateUsersWithArrayInputMutationProps<T extends keyof CreateUsersWithArrayInputProps> =
+	Omit<CreateUsersWithArrayInputProps, T> & Partial<Pick<CreateUsersWithArrayInputProps, T>>;
+
 /**
  *
  */
-export function useCreateUsersWithArrayInputMutation(
-	props: CreateUsersWithArrayInputProps,
+export function useCreateUsersWithArrayInputMutation<
+	T extends keyof CreateUsersWithArrayInputProps,
+>(
+	props: Pick<Partial<CreateUsersWithArrayInputProps>, T>,
 	options?: Omit<
-		UseMutationOptions<CreateUsersWithArrayInputOkResponse, CreateUsersWithArrayInputErrorResponse>,
+		UseMutationOptions<
+			CreateUsersWithArrayInputOkResponse,
+			CreateUsersWithArrayInputErrorResponse,
+			CreateUsersWithArrayInputMutationProps<T>
+		>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<CreateUsersWithArrayInputOkResponse, CreateUsersWithArrayInputErrorResponse>(
-		() => createUsersWithArrayInput(props),
+	return useMutation<
+		CreateUsersWithArrayInputOkResponse,
+		CreateUsersWithArrayInputErrorResponse,
+		CreateUsersWithArrayInputMutationProps<T>
+	>(
+		(mutateProps: CreateUsersWithArrayInputMutationProps<T>) =>
+			createUsersWithArrayInput({ ...props, ...mutateProps } as CreateUsersWithArrayInputProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/hooks/useCreateUsersWithListInputMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUsersWithListInputMutation.ts
@@ -28,18 +28,30 @@ export function createUsersWithListInput(
 	});
 }
 
+export type CreateUsersWithListInputMutationProps<T extends keyof CreateUsersWithListInputProps> =
+	Omit<CreateUsersWithListInputProps, T> & Partial<Pick<CreateUsersWithListInputProps, T>>;
+
 /**
  *
  */
-export function useCreateUsersWithListInputMutation(
-	props: CreateUsersWithListInputProps,
+export function useCreateUsersWithListInputMutation<T extends keyof CreateUsersWithListInputProps>(
+	props: Pick<Partial<CreateUsersWithListInputProps>, T>,
 	options?: Omit<
-		UseMutationOptions<CreateUsersWithListInputOkResponse, CreateUsersWithListInputErrorResponse>,
+		UseMutationOptions<
+			CreateUsersWithListInputOkResponse,
+			CreateUsersWithListInputErrorResponse,
+			CreateUsersWithListInputMutationProps<T>
+		>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<CreateUsersWithListInputOkResponse, CreateUsersWithListInputErrorResponse>(
-		() => createUsersWithListInput(props),
+	return useMutation<
+		CreateUsersWithListInputOkResponse,
+		CreateUsersWithListInputErrorResponse,
+		CreateUsersWithListInputMutationProps<T>
+	>(
+		(mutateProps: CreateUsersWithListInputMutationProps<T>) =>
+			createUsersWithListInput({ ...props, ...mutateProps } as CreateUsersWithListInputProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/hooks/useDeleteOrderMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeleteOrderMutation.ts
@@ -29,18 +29,26 @@ export function deleteOrder(props: DeleteOrderProps): Promise<DeleteOrderOkRespo
 	});
 }
 
+export type DeleteOrderMutationProps<T extends keyof DeleteOrderProps> = Omit<DeleteOrderProps, T> &
+	Partial<Pick<DeleteOrderProps, T>>;
+
 /**
  * For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
  */
-export function useDeleteOrderMutation(
-	props: DeleteOrderProps,
+export function useDeleteOrderMutation<T extends keyof DeleteOrderProps>(
+	props: Pick<Partial<DeleteOrderProps>, T>,
 	options?: Omit<
-		UseMutationOptions<DeleteOrderOkResponse, DeleteOrderErrorResponse>,
+		UseMutationOptions<
+			DeleteOrderOkResponse,
+			DeleteOrderErrorResponse,
+			DeleteOrderMutationProps<T>
+		>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<DeleteOrderOkResponse, DeleteOrderErrorResponse>(
-		() => deleteOrder(props),
+	return useMutation<DeleteOrderOkResponse, DeleteOrderErrorResponse, DeleteOrderMutationProps<T>>(
+		(mutateProps: DeleteOrderMutationProps<T>) =>
+			deleteOrder({ ...props, ...mutateProps } as DeleteOrderProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
@@ -29,15 +29,22 @@ export function deletePet(props: DeletePetProps): Promise<DeletePetOkResponse> {
 	});
 }
 
+export type DeletePetMutationProps<T extends keyof DeletePetProps> = Omit<DeletePetProps, T> &
+	Partial<Pick<DeletePetProps, T>>;
+
 /**
  *
  */
-export function useDeletePetMutation(
-	props: DeletePetProps,
+export function useDeletePetMutation<T extends keyof DeletePetProps>(
+	props: Pick<Partial<DeletePetProps>, T>,
 	options?: Omit<
-		UseMutationOptions<DeletePetOkResponse, DeletePetErrorResponse>,
+		UseMutationOptions<DeletePetOkResponse, DeletePetErrorResponse, DeletePetMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<DeletePetOkResponse, DeletePetErrorResponse>(() => deletePet(props), options);
+	return useMutation<DeletePetOkResponse, DeletePetErrorResponse, DeletePetMutationProps<T>>(
+		(mutateProps: DeletePetMutationProps<T>) =>
+			deletePet({ ...props, ...mutateProps } as DeletePetProps),
+		options,
+	);
 }

--- a/examples/output/petstore-swagger/hooks/useDeleteUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeleteUserMutation.ts
@@ -26,18 +26,22 @@ export function deleteUser(props: DeleteUserProps): Promise<DeleteUserOkResponse
 	});
 }
 
+export type DeleteUserMutationProps<T extends keyof DeleteUserProps> = Omit<DeleteUserProps, T> &
+	Partial<Pick<DeleteUserProps, T>>;
+
 /**
  * This can only be done by the logged in user.
  */
-export function useDeleteUserMutation(
-	props: DeleteUserProps,
+export function useDeleteUserMutation<T extends keyof DeleteUserProps>(
+	props: Pick<Partial<DeleteUserProps>, T>,
 	options?: Omit<
-		UseMutationOptions<DeleteUserOkResponse, DeleteUserErrorResponse>,
+		UseMutationOptions<DeleteUserOkResponse, DeleteUserErrorResponse, DeleteUserMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<DeleteUserOkResponse, DeleteUserErrorResponse>(
-		() => deleteUser(props),
+	return useMutation<DeleteUserOkResponse, DeleteUserErrorResponse, DeleteUserMutationProps<T>>(
+		(mutateProps: DeleteUserMutationProps<T>) =>
+			deleteUser({ ...props, ...mutateProps } as DeleteUserProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/hooks/usePlaceOrderMutation.ts
+++ b/examples/output/petstore-swagger/hooks/usePlaceOrderMutation.ts
@@ -26,18 +26,22 @@ export function placeOrder(props: PlaceOrderProps): Promise<PlaceOrderOkResponse
 	});
 }
 
+export type PlaceOrderMutationProps<T extends keyof PlaceOrderProps> = Omit<PlaceOrderProps, T> &
+	Partial<Pick<PlaceOrderProps, T>>;
+
 /**
  *
  */
-export function usePlaceOrderMutation(
-	props: PlaceOrderProps,
+export function usePlaceOrderMutation<T extends keyof PlaceOrderProps>(
+	props: Pick<Partial<PlaceOrderProps>, T>,
 	options?: Omit<
-		UseMutationOptions<PlaceOrderOkResponse, PlaceOrderErrorResponse>,
+		UseMutationOptions<PlaceOrderOkResponse, PlaceOrderErrorResponse, PlaceOrderMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<PlaceOrderOkResponse, PlaceOrderErrorResponse>(
-		() => placeOrder(props),
+	return useMutation<PlaceOrderOkResponse, PlaceOrderErrorResponse, PlaceOrderMutationProps<T>>(
+		(mutateProps: PlaceOrderMutationProps<T>) =>
+			placeOrder({ ...props, ...mutateProps } as PlaceOrderProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/hooks/useUpdatePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdatePetMutation.ts
@@ -25,15 +25,22 @@ export function updatePet(props: UpdatePetProps): Promise<UpdatePetOkResponse> {
 	});
 }
 
+export type UpdatePetMutationProps<T extends keyof UpdatePetProps> = Omit<UpdatePetProps, T> &
+	Partial<Pick<UpdatePetProps, T>>;
+
 /**
  *
  */
-export function useUpdatePetMutation(
-	props: UpdatePetProps,
+export function useUpdatePetMutation<T extends keyof UpdatePetProps>(
+	props: Pick<Partial<UpdatePetProps>, T>,
 	options?: Omit<
-		UseMutationOptions<UpdatePetOkResponse, UpdatePetErrorResponse>,
+		UseMutationOptions<UpdatePetOkResponse, UpdatePetErrorResponse, UpdatePetMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<UpdatePetOkResponse, UpdatePetErrorResponse>(() => updatePet(props), options);
+	return useMutation<UpdatePetOkResponse, UpdatePetErrorResponse, UpdatePetMutationProps<T>>(
+		(mutateProps: UpdatePetMutationProps<T>) =>
+			updatePet({ ...props, ...mutateProps } as UpdatePetProps),
+		options,
+	);
 }

--- a/examples/output/petstore-swagger/hooks/useUpdatePetWithFormMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdatePetWithFormMutation.ts
@@ -35,18 +35,33 @@ export function updatePetWithForm(
 	});
 }
 
+export type UpdatePetWithFormMutationProps<T extends keyof UpdatePetWithFormProps> = Omit<
+	UpdatePetWithFormProps,
+	T
+> &
+	Partial<Pick<UpdatePetWithFormProps, T>>;
+
 /**
  *
  */
-export function useUpdatePetWithFormMutation(
-	props: UpdatePetWithFormProps,
+export function useUpdatePetWithFormMutation<T extends keyof UpdatePetWithFormProps>(
+	props: Pick<Partial<UpdatePetWithFormProps>, T>,
 	options?: Omit<
-		UseMutationOptions<UpdatePetWithFormOkResponse, UpdatePetWithFormErrorResponse>,
+		UseMutationOptions<
+			UpdatePetWithFormOkResponse,
+			UpdatePetWithFormErrorResponse,
+			UpdatePetWithFormMutationProps<T>
+		>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<UpdatePetWithFormOkResponse, UpdatePetWithFormErrorResponse>(
-		() => updatePetWithForm(props),
+	return useMutation<
+		UpdatePetWithFormOkResponse,
+		UpdatePetWithFormErrorResponse,
+		UpdatePetWithFormMutationProps<T>
+	>(
+		(mutateProps: UpdatePetWithFormMutationProps<T>) =>
+			updatePetWithForm({ ...props, ...mutateProps } as UpdatePetWithFormProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/hooks/useUpdateUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdateUserMutation.ts
@@ -31,18 +31,22 @@ export function updateUser(props: UpdateUserProps): Promise<UpdateUserOkResponse
 	});
 }
 
+export type UpdateUserMutationProps<T extends keyof UpdateUserProps> = Omit<UpdateUserProps, T> &
+	Partial<Pick<UpdateUserProps, T>>;
+
 /**
  * This can only be done by the logged in user.
  */
-export function useUpdateUserMutation(
-	props: UpdateUserProps,
+export function useUpdateUserMutation<T extends keyof UpdateUserProps>(
+	props: Pick<Partial<UpdateUserProps>, T>,
 	options?: Omit<
-		UseMutationOptions<UpdateUserOkResponse, UpdateUserErrorResponse>,
+		UseMutationOptions<UpdateUserOkResponse, UpdateUserErrorResponse, UpdateUserMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<UpdateUserOkResponse, UpdateUserErrorResponse>(
-		() => updateUser(props),
+	return useMutation<UpdateUserOkResponse, UpdateUserErrorResponse, UpdateUserMutationProps<T>>(
+		(mutateProps: UpdateUserMutationProps<T>) =>
+			updateUser({ ...props, ...mutateProps } as UpdateUserProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/hooks/useUploadFileMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUploadFileMutation.ts
@@ -34,18 +34,22 @@ export function uploadFile(props: UploadFileProps): Promise<UploadFileOkResponse
 	});
 }
 
+export type UploadFileMutationProps<T extends keyof UploadFileProps> = Omit<UploadFileProps, T> &
+	Partial<Pick<UploadFileProps, T>>;
+
 /**
  *
  */
-export function useUploadFileMutation(
-	props: UploadFileProps,
+export function useUploadFileMutation<T extends keyof UploadFileProps>(
+	props: Pick<Partial<UploadFileProps>, T>,
 	options?: Omit<
-		UseMutationOptions<UploadFileOkResponse, UploadFileErrorResponse>,
+		UseMutationOptions<UploadFileOkResponse, UploadFileErrorResponse, UploadFileMutationProps<T>>,
 		'mutationKey' | 'mutationFn'
 	>,
 ) {
-	return useMutation<UploadFileOkResponse, UploadFileErrorResponse>(
-		() => uploadFile(props),
+	return useMutation<UploadFileOkResponse, UploadFileErrorResponse, UploadFileMutationProps<T>>(
+		(mutateProps: UploadFileMutationProps<T>) =>
+			uploadFile({ ...props, ...mutateProps } as UploadFileProps),
 		options,
 	);
 }

--- a/examples/output/petstore-swagger/index.ts
+++ b/examples/output/petstore-swagger/index.ts
@@ -1,5 +1,6 @@
 export type {
 	AddPetErrorResponse,
+	AddPetMutationProps,
 	AddPetOkResponse,
 	AddPetProps,
 	AddPetRequestBody,
@@ -7,6 +8,7 @@ export type {
 export { addPet, useAddPetMutation } from './hooks/useAddPetMutation';
 export type {
 	CreateUserErrorResponse,
+	CreateUserMutationProps,
 	CreateUserOkResponse,
 	CreateUserProps,
 	CreateUserRequestBody,
@@ -14,6 +16,7 @@ export type {
 export { createUser, useCreateUserMutation } from './hooks/useCreateUserMutation';
 export type {
 	CreateUsersWithArrayInputErrorResponse,
+	CreateUsersWithArrayInputMutationProps,
 	CreateUsersWithArrayInputOkResponse,
 	CreateUsersWithArrayInputProps,
 	CreateUsersWithArrayInputRequestBody,
@@ -24,6 +27,7 @@ export {
 } from './hooks/useCreateUsersWithArrayInputMutation';
 export type {
 	CreateUsersWithListInputErrorResponse,
+	CreateUsersWithListInputMutationProps,
 	CreateUsersWithListInputOkResponse,
 	CreateUsersWithListInputProps,
 	CreateUsersWithListInputRequestBody,
@@ -35,6 +39,7 @@ export {
 export type {
 	DeleteOrderErrorResponse,
 	DeleteOrderMutationPathParams,
+	DeleteOrderMutationProps,
 	DeleteOrderOkResponse,
 	DeleteOrderProps,
 } from './hooks/useDeleteOrderMutation';
@@ -42,6 +47,7 @@ export { deleteOrder, useDeleteOrderMutation } from './hooks/useDeleteOrderMutat
 export type {
 	DeletePetErrorResponse,
 	DeletePetMutationPathParams,
+	DeletePetMutationProps,
 	DeletePetOkResponse,
 	DeletePetProps,
 } from './hooks/useDeletePetMutation';
@@ -49,6 +55,7 @@ export { deletePet, useDeletePetMutation } from './hooks/useDeletePetMutation';
 export type {
 	DeleteUserErrorResponse,
 	DeleteUserMutationPathParams,
+	DeleteUserMutationProps,
 	DeleteUserOkResponse,
 	DeleteUserProps,
 } from './hooks/useDeleteUserMutation';
@@ -109,6 +116,7 @@ export type {
 export { logoutUser, useLogoutUserQuery } from './hooks/useLogoutUserQuery';
 export type {
 	PlaceOrderErrorResponse,
+	PlaceOrderMutationProps,
 	PlaceOrderOkResponse,
 	PlaceOrderProps,
 	PlaceOrderRequestBody,
@@ -116,6 +124,7 @@ export type {
 export { placeOrder, usePlaceOrderMutation } from './hooks/usePlaceOrderMutation';
 export type {
 	UpdatePetErrorResponse,
+	UpdatePetMutationProps,
 	UpdatePetOkResponse,
 	UpdatePetProps,
 	UpdatePetRequestBody,
@@ -124,6 +133,7 @@ export { updatePet, useUpdatePetMutation } from './hooks/useUpdatePetMutation';
 export type {
 	UpdatePetWithFormErrorResponse,
 	UpdatePetWithFormMutationPathParams,
+	UpdatePetWithFormMutationProps,
 	UpdatePetWithFormOkResponse,
 	UpdatePetWithFormProps,
 	UpdatePetWithFormRequestBody,
@@ -135,6 +145,7 @@ export {
 export type {
 	UpdateUserErrorResponse,
 	UpdateUserMutationPathParams,
+	UpdateUserMutationProps,
 	UpdateUserOkResponse,
 	UpdateUserProps,
 	UpdateUserRequestBody,
@@ -143,6 +154,7 @@ export { updateUser, useUpdateUserMutation } from './hooks/useUpdateUserMutation
 export type {
 	UploadFileErrorResponse,
 	UploadFileMutationPathParams,
+	UploadFileMutationProps,
 	UploadFileOkResponse,
 	UploadFileProps,
 	UploadFileRequestBody,

--- a/packages/plugin-react-query/src/generateReactQueryHooks.mts
+++ b/packages/plugin-react-query/src/generateReactQueryHooks.mts
@@ -76,6 +76,7 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 			const hookName = `use${typeName}${suffix}`;
 			const fetcherName = `${camelCase(operation.operationId)}`;
 			const fetcherPropsName = `${typeName}Props`;
+			const mutationPropsName = `${typeName}MutationProps`;
 			const pathParamsName = `${typeName}${suffix}PathParams`;
 			const queryParamsName = `${typeName}${suffix}QueryParams`;
 			const requestBodyName = getNameForRequestBody(operation.operationId);
@@ -107,6 +108,7 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 			const templateProps = {
 				hookName,
 				fetcherPropsName,
+				mutationPropsName,
 				fetcherName,
 				requestBodyName,
 				requestBodyCode,
@@ -123,13 +125,13 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 				queryParamsName,
 				queryParamsCode,
 				pathParamsNamesList: params.path.map((p) => p.name),
+				description: liquid.renderSync(COMMENTS_TEMPLATE, { schema: operation }).trimEnd(),
 			};
 
 			const code = [
 				liquid.renderSync(COMMON_TEMPLATE, templateProps).trim(),
-				liquid.renderSync(COMMENTS_TEMPLATE, { schema: operation }).trimEnd(),
 				liquid.renderSync(useUseQuery ? QUERY_TEMPLATE : MUTATION_TEMPLATE, templateProps).trim(),
-			].join('\n');
+			].join('\n\n');
 
 			const typeExports = [fetcherPropsName, okResponseName, errorResponseName];
 			const jsExports = [hookName, fetcherName];
@@ -153,6 +155,7 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 					...imports,
 				]);
 			} else {
+				typeExports.push(mutationPropsName);
 				imports = new Set([
 					'import { useMutation, UseMutationOptions } from "@tanstack/react-query";',
 					'',

--- a/packages/plugin-react-query/src/templates/useMutationHook.liquid
+++ b/packages/plugin-react-query/src/templates/useMutationHook.liquid
@@ -1,6 +1,17 @@
-export function {{hookName}}(
-  props: {{fetcherPropsName}},
-  options?: Omit<UseMutationOptions<{{okResponseName}}, {{errorResponseName}}>, 'mutationKey' | 'mutationFn'>
+export type {{mutationPropsName}}<T extends keyof {{fetcherPropsName}}> = Omit<{{fetcherPropsName}}, T> &
+	Partial<Pick<{{fetcherPropsName}}, T>>
+
+{{description}}
+export function {{hookName}}<T extends keyof {{fetcherPropsName}}>(
+  props: Pick<Partial<{{fetcherPropsName}}>, T>,
+  options?: Omit<UseMutationOptions<{{okResponseName}}, {{errorResponseName}},  {{mutationPropsName}}<T>>, 'mutationKey' | 'mutationFn'>
 ) {
-  return useMutation<{{okResponseName}}, {{errorResponseName}}>(() => {{fetcherName}}(props), options)
+  return useMutation<
+    {{okResponseName}},
+    {{errorResponseName}},
+    {{mutationPropsName}}<T>
+  >(
+    (mutateProps:  {{mutationPropsName}}<T>) => {{fetcherName}}({ ...props, ...mutateProps } as {{fetcherPropsName}}),
+    options
+  )
 }

--- a/packages/plugin-react-query/src/templates/useQueryHook.liquid
+++ b/packages/plugin-react-query/src/templates/useQueryHook.liquid
@@ -1,3 +1,4 @@
+{{description}}
 export function {{hookName}}(
   props: {{fetcherPropsName}},
   options?: Omit<UseQueryOptions<{{okResponseName}}, {{errorResponseName}}>, 'queryKey' | 'queryFn'>


### PR DESCRIPTION
### Summary

This change is to make mutate function accept arguments.

Before:

```ts
const {  mutate } = useAddPetMutation({ 
 // you had to give parameters here
 })

mutate({body: {}}) // This did not work. Mutate would still use the data defined above.
```

After:

```ts
const {  mutate } = useAddPetMutation({ 
 // Now the parameters are optional
 })

mutate({body: {}}) // This will now work. And the parameters defined above will be marked as optional here.
```

As you can see in the images below, if body is not defined in the hook, it's required in mutate and when it's defined in hook, its marked as optional in mutate.

![image](https://user-images.githubusercontent.com/110581558/208608853-7a152e1a-a4eb-4b16-ac51-4559bf0e104e.png)

![image](https://user-images.githubusercontent.com/110581558/208609025-f5626523-26b1-4b3e-aad5-9df2b96f7a9d.png)

**The options are merged shallowly**


<!-- ✍️ Add screenshots of before and after changes where applicable-->

## [Contributor license agreement](https://github.com/harness/oats/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md)
