### PR TITLE
feat: add support for header params

### DIFF
--- a/.changeset/rude-suns-develop.md
+++ b/.changeset/rude-suns-develop.md
@@ -1,0 +1,5 @@
+---
+'@harnessio/oats-plugin-react-query': minor
+---
+
+Added support for header params

--- a/examples/output/github/hooks/fetcher.ts
+++ b/examples/output/github/hooks/fetcher.ts
@@ -1,19 +1,27 @@
-export interface FetcherOptions<TQueryParams = never, TBody = never>
-	extends Omit<RequestInit, 'body'> {
+export interface FetcherOptions<TQueryParams = never, TBody = never, THeaderParams = HeadersInit>
+	extends Omit<RequestInit, 'body' | 'headers'> {
 	url: string;
 	queryParams?: TQueryParams extends never ? undefined : TQueryParams;
 	body?: TBody extends never ? undefined : TBody;
+	headers?: THeaderParams;
 }
 
 const JSON_HEADERS = ['application/json'];
 
-export async function fetcher<TResponse = unknown, TQueryParams = never, TBody = never>(
-	options: FetcherOptions<TQueryParams, TBody>,
-): Promise<TResponse> {
-	const { body, url, queryParams, ...rest } = options;
+export async function fetcher<
+	TResponse = unknown,
+	TQueryParams = never,
+	TBody = never,
+	THeaderParams = HeadersInit,
+>(options: FetcherOptions<TQueryParams, TBody, THeaderParams>): Promise<TResponse> {
+	const { body, url, queryParams, headers, ...rest } = options;
 
 	const response = await fetch(url, {
 		body: body ? JSON.stringify(body) : undefined,
+		headers: {
+			'Content-Type': JSON_HEADERS[0],
+			...(headers as HeadersInit),
+		},
 		...rest,
 	});
 

--- a/examples/output/petstore-openapi-v3.0/hooks/fetcher.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/fetcher.ts
@@ -1,19 +1,27 @@
-export interface FetcherOptions<TQueryParams = never, TBody = never>
-	extends Omit<RequestInit, 'body'> {
+export interface FetcherOptions<TQueryParams = never, TBody = never, THeaderParams = HeadersInit>
+	extends Omit<RequestInit, 'body' | 'headers'> {
 	url: string;
 	queryParams?: TQueryParams extends never ? undefined : TQueryParams;
 	body?: TBody extends never ? undefined : TBody;
+	headers?: THeaderParams;
 }
 
 const JSON_HEADERS = ['application/json'];
 
-export async function fetcher<TResponse = unknown, TQueryParams = never, TBody = never>(
-	options: FetcherOptions<TQueryParams, TBody>,
-): Promise<TResponse> {
-	const { body, url, queryParams, ...rest } = options;
+export async function fetcher<
+	TResponse = unknown,
+	TQueryParams = never,
+	TBody = never,
+	THeaderParams = HeadersInit,
+>(options: FetcherOptions<TQueryParams, TBody, THeaderParams>): Promise<TResponse> {
+	const { body, url, queryParams, headers, ...rest } = options;
 
 	const response = await fetch(url, {
 		body: body ? JSON.stringify(body) : undefined,
+		headers: {
+			'Content-Type': JSON_HEADERS[0],
+			...(headers as HeadersInit),
+		},
 		...rest,
 	});
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
@@ -12,16 +12,20 @@ export interface DeletePetMutationPathParams {
 	petId: number;
 }
 
+export interface DeletePetMutationHeaderParams {
+	api_key?: string;
+}
+
 export type DeletePetOkResponse = unknown;
 
 export type DeletePetErrorResponse = unknown;
 
 export interface DeletePetProps
 	extends DeletePetMutationPathParams,
-		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
+		Omit<FetcherOptions<unknown, unknown, DeletePetMutationHeaderParams>, 'url'> {}
 
 export function deletePet(props: DeletePetProps): Promise<DeletePetOkResponse> {
-	return fetcher<DeletePetOkResponse, unknown, unknown>({
+	return fetcher<DeletePetOkResponse, unknown, unknown, DeletePetMutationHeaderParams>({
 		url: `/pet/${props.petId}`,
 		method: 'DELETE',
 		...props,

--- a/examples/output/petstore-swagger/hooks/fetcher.ts
+++ b/examples/output/petstore-swagger/hooks/fetcher.ts
@@ -1,20 +1,28 @@
 /* This is a sample header */
-export interface FetcherOptions<TQueryParams = never, TBody = never>
-	extends Omit<RequestInit, 'body'> {
+export interface FetcherOptions<TQueryParams = never, TBody = never, THeaderParams = HeadersInit>
+	extends Omit<RequestInit, 'body' | 'headers'> {
 	url: string;
 	queryParams?: TQueryParams extends never ? undefined : TQueryParams;
 	body?: TBody extends never ? undefined : TBody;
+	headers?: THeaderParams;
 }
 
 const JSON_HEADERS = ['application/json'];
 
-export async function fetcher<TResponse = unknown, TQueryParams = never, TBody = never>(
-	options: FetcherOptions<TQueryParams, TBody>,
-): Promise<TResponse> {
-	const { body, url, queryParams, ...rest } = options;
+export async function fetcher<
+	TResponse = unknown,
+	TQueryParams = never,
+	TBody = never,
+	THeaderParams = HeadersInit,
+>(options: FetcherOptions<TQueryParams, TBody, THeaderParams>): Promise<TResponse> {
+	const { body, url, queryParams, headers, ...rest } = options;
 
 	const response = await fetch(url, {
 		body: body ? JSON.stringify(body) : undefined,
+		headers: {
+			'Content-Type': JSON_HEADERS[0],
+			...(headers as HeadersInit),
+		},
 		...rest,
 	});
 

--- a/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
@@ -13,16 +13,20 @@ export interface DeletePetMutationPathParams {
 	petId: number;
 }
 
+export interface DeletePetMutationHeaderParams {
+	api_key?: string;
+}
+
 export type DeletePetOkResponse = unknown;
 
 export type DeletePetErrorResponse = unknown;
 
 export interface DeletePetProps
 	extends DeletePetMutationPathParams,
-		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
+		Omit<FetcherOptions<unknown, unknown, DeletePetMutationHeaderParams>, 'url'> {}
 
 export function deletePet(props: DeletePetProps): Promise<DeletePetOkResponse> {
-	return fetcher<DeletePetOkResponse, unknown, unknown>({
+	return fetcher<DeletePetOkResponse, unknown, unknown, DeletePetMutationHeaderParams>({
 		url: `/pet/${props.petId}`,
 		method: 'DELETE',
 		...props,

--- a/packages/plugin-react-query/src/generateReactQueryHooks.mts
+++ b/packages/plugin-react-query/src/generateReactQueryHooks.mts
@@ -79,6 +79,7 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 			const mutationPropsName = `${typeName}MutationProps`;
 			const pathParamsName = `${typeName}${suffix}PathParams`;
 			const queryParamsName = `${typeName}${suffix}QueryParams`;
+			const headerParamsName = `${typeName}${suffix}HeaderParams`;
 			const requestBodyName = getNameForRequestBody(operation.operationId);
 			const okResponseName = getNameForOkResponse(operation.operationId);
 			const errorResponseName = getNameForErrorResponse(operation.operationId);
@@ -100,10 +101,15 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 
 			const pathParams = params.path.map(processParams);
 			const queryParams = params.query.map(processParams);
+			const headerParams = params.header.map(processParams);
 			const pathParamsCode =
 				pathParams.length > 0 ? liquid.renderSync(OBJECT_TEMPLATE, { props: pathParams }) : null;
 			const queryParamsCode =
 				queryParams.length > 0 ? liquid.renderSync(OBJECT_TEMPLATE, { props: queryParams }) : null;
+			const headerParamsCode =
+				headerParams.length > 0
+					? liquid.renderSync(OBJECT_TEMPLATE, { props: headerParams })
+					: null;
 
 			const templateProps = {
 				hookName,
@@ -124,6 +130,8 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 				pathParamsCode,
 				queryParamsName,
 				queryParamsCode,
+				headerParamsName,
+				headerParamsCode,
 				pathParamsNamesList: params.path.map((p) => p.name),
 				description: liquid.renderSync(COMMENTS_TEMPLATE, { schema: operation }).trimEnd(),
 			};

--- a/packages/plugin-react-query/src/templates/defaultFetcher.liquid
+++ b/packages/plugin-react-query/src/templates/defaultFetcher.liquid
@@ -1,19 +1,27 @@
-export interface FetcherOptions<TQueryParams = never, TBody = never>
-	extends Omit<RequestInit, 'body'> {
+export interface FetcherOptions<TQueryParams = never, TBody = never, THeaderParams = HeadersInit>
+	extends Omit<RequestInit, 'body' | 'headers'> {
 	url: string;
 	queryParams?: TQueryParams extends never ? undefined : TQueryParams;
 	body?: TBody extends never ? undefined : TBody;
+	headers?: THeaderParams;
 }
 
 const JSON_HEADERS = ['application/json'];
 
-export async function fetcher<TResponse = unknown, TQueryParams = never, TBody = never>(
-	options: FetcherOptions<TQueryParams, TBody>,
-): Promise<TResponse> {
-	const { body, url, queryParams, ...rest } = options;
+export async function fetcher<
+	TResponse = unknown,
+	TQueryParams = never,
+	TBody = never,
+	THeaderParams = HeadersInit,
+>(options: FetcherOptions<TQueryParams, TBody, THeaderParams>): Promise<TResponse> {
+	const { body, url, queryParams, headers, ...rest } = options;
 
 	const response = await fetch(url, {
 		body: body ? JSON.stringify(body) : undefined,
+		headers: {
+			'Content-Type': JSON_HEADERS[0],
+			...(headers as HeadersInit),
+		},
 		...rest,
 	});
 

--- a/packages/plugin-react-query/src/templates/reactQueryCommon.liquid
+++ b/packages/plugin-react-query/src/templates/reactQueryCommon.liquid
@@ -6,6 +6,10 @@ export interface {{pathParamsName}} {{pathParamsCode}}
 export interface {{queryParamsName}} {{queryParamsCode}}
 {% endif %}
 
+{% if headerParamsCode %}
+export interface {{headerParamsName}} {{headerParamsCode}}
+{% endif %}
+
 {% if requestBodyCode %}
 export type {{requestBodyName}} = {{requestBodyCode}};
 {% endif %}
@@ -25,6 +29,7 @@ export interface {{fetcherPropsName}} extends
 Omit<FetcherOptions<
   {% if queryParamsCode -%}{{queryParamsName}}{% else %}unknown{%- endif %},
   {% if requestBodyCode %}{{requestBodyName}}{% else %}unknown{%- endif %}
+  {% if headerParamsCode %},{{headerParamsName}}{%- endif %}
 >, 'url'> {
   {% if queryParamsCode -%}
   queryParams: {{queryParamsName}};
@@ -39,6 +44,7 @@ export function {{fetcherName}}(props: {{fetcherPropsName}}): Promise<{{okRespon
     {{okResponseName}},
     {% if queryParamsCode -%}{{queryParamsName}}{% else %}unknown{%- endif %},
     {% if requestBodyCode %}{{requestBodyName}}{% else %}unknown{%- endif %}
+    {% if headerParamsCode %},{{headerParamsName}}{%- endif %}
   >({
     url: `{{route | path_to_template}}`,
     method: {{verb | upcase | json}},


### PR DESCRIPTION
### Summary

add support for header params in `react-query-plugin`

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

## [Contributor license agreement](https://github.com/harness/oats/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md)
