### PR TITLE
fix: operationID map filtered based on config allowedOperationId list

### DIFF
--- a/.changeset/eight-keys-end.md
+++ b/.changeset/eight-keys-end.md
@@ -1,0 +1,5 @@
+---
+'@harnessio/oats-plugin-react-query-harness': minor
+---
+
+operationID map filtered based on config allowedOperationId list

--- a/.changeset/lemon-pandas-sparkle.md
+++ b/.changeset/lemon-pandas-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@harnessio/oats-plugin-react-query-harness': patch
+---
+
+operationID map filtered based on config allowedOperationId list

--- a/packages/plugin-react-query-harness/src/generateReactQueryHooks.mts
+++ b/packages/plugin-react-query-harness/src/generateReactQueryHooks.mts
@@ -151,6 +151,12 @@ export function generateReactQueryHooks(unsafeConfig?: IConfig): IPlugin['genera
 		}
 
 		// generate code for rest of the operations
+		if (config && Array.isArray(config.allowedOperationIds)) {
+			config.allowedOperationIds.forEach((opId) => {
+				operationIdMap.delete(opId);
+			});
+		}
+
 		operationIdMap.forEach((op) => {
 			files.push(processOperation(op, config));
 		});


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

## [Contributor license agreement](https://github.com/harness/oats/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md)
