### PR TITLE
fix: [CDS-83878]: added unique operation id for grouped query hook

### DIFF
--- a/.changeset/long-files-raise.md
+++ b/.changeset/long-files-raise.md
@@ -1,0 +1,5 @@
+---
+'@harnessio/oats-plugin-react-query-harness': minor
+---
+
+added unique operation id for grouped query hook

--- a/packages/plugin-react-query-harness/src/templates/groupedQueryHook.liquid
+++ b/packages/plugin-react-query-harness/src/templates/groupedQueryHook.liquid
@@ -14,7 +14,7 @@ export function {{hookName}}<T extends {{fetcherPropsName}} = {{fetcherPropsName
     {{errorResponseName}}<GetPathParamsType<T>>
   >(
     [
-      {{operation.operationId | json}}
+      {{fetcherName | json}}
       {% if pathParamsCode -%}
       {% for name in pathParamsNamesList -%}
       , props{{name | property_accessor}}


### PR DESCRIPTION
### Summary

- the operation id being passed to the template was not being set in `templateProps` passed to the grouped query hook

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

## [Contributor license agreement](https://github.com/harness/oats/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md)
