### PR TITLE
fix: Fixing return type for response headers

### DIFF
--- a/examples/output/github/hooks/fetcher.ts
+++ b/examples/output/github/hooks/fetcher.ts
@@ -9,7 +9,7 @@ export interface FetcherOptions<TQueryParams = never, TBody = never, THeaderPara
 const JSON_HEADERS = ['application/json'];
 
 interface ResponseContainer<TResponse, TResponseHeaders> {
-	content: TResponse;
+	body: TResponse;
 	headers: TResponseHeaders;
 }
 
@@ -39,7 +39,7 @@ export async function fetcher<
 
 	if (response.ok) {
 		return {
-			content: data,
+			body: data,
 			headers: response.headers,
 		};
 	}

--- a/examples/output/github/hooks/fetcher.ts
+++ b/examples/output/github/hooks/fetcher.ts
@@ -20,7 +20,7 @@ export async function fetcher<
 	THeaderParams = HeadersInit,
 >(
 	options: FetcherOptions<TQueryParams, TBody, THeaderParams>,
-): Promise<ResponseContainer<TResponse, Record<string, any>>> {
+): Promise<ResponseContainer<TResponse, Headers>> {
 	const { body, url, queryParams, headers, ...rest } = options;
 
 	const response = await fetch(url, {
@@ -40,7 +40,7 @@ export async function fetcher<
 	if (response.ok) {
 		return {
 			content: data,
-			headers: {},
+			headers: response.headers,
 		};
 	}
 

--- a/examples/output/github/hooks/useReposListForAuthenticatedUserQuery.ts
+++ b/examples/output/github/hooks/useReposListForAuthenticatedUserQuery.ts
@@ -60,7 +60,7 @@ export interface ReposListForAuthenticatedUserProps
 }
 
 export interface ReposListForAuthenticatedUserResponseContainer {
-	content: ReposListForAuthenticatedUserOkResponse;
+	body: ReposListForAuthenticatedUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/github/hooks/useReposListForAuthenticatedUserQuery.ts
+++ b/examples/output/github/hooks/useReposListForAuthenticatedUserQuery.ts
@@ -61,7 +61,7 @@ export interface ReposListForAuthenticatedUserProps
 
 export interface ReposListForAuthenticatedUserResponseContainer {
 	content: ReposListForAuthenticatedUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function reposListForAuthenticatedUser(

--- a/examples/output/github/hooks/useReposListForAuthenticatedUserQuery.ts
+++ b/examples/output/github/hooks/useReposListForAuthenticatedUserQuery.ts
@@ -61,7 +61,7 @@ export interface ReposListForAuthenticatedUserProps
 
 export interface ReposListForAuthenticatedUserResponseContainer {
 	content: ReposListForAuthenticatedUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function reposListForAuthenticatedUser(

--- a/examples/output/petstore-openapi-v3.0/hooks/fetcher.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/fetcher.ts
@@ -9,7 +9,7 @@ export interface FetcherOptions<TQueryParams = never, TBody = never, THeaderPara
 const JSON_HEADERS = ['application/json'];
 
 interface ResponseContainer<TResponse, TResponseHeaders> {
-	content: TResponse;
+	body: TResponse;
 	headers: TResponseHeaders;
 }
 
@@ -39,7 +39,7 @@ export async function fetcher<
 
 	if (response.ok) {
 		return {
-			content: data,
+			body: data,
 			headers: response.headers,
 		};
 	}

--- a/examples/output/petstore-openapi-v3.0/hooks/fetcher.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/fetcher.ts
@@ -20,7 +20,7 @@ export async function fetcher<
 	THeaderParams = HeadersInit,
 >(
 	options: FetcherOptions<TQueryParams, TBody, THeaderParams>,
-): Promise<ResponseContainer<TResponse, Record<string, any>>> {
+): Promise<ResponseContainer<TResponse, Headers>> {
 	const { body, url, queryParams, headers, ...rest } = options;
 
 	const response = await fetch(url, {
@@ -40,7 +40,7 @@ export async function fetcher<
 	if (response.ok) {
 		return {
 			content: data,
-			headers: {},
+			headers: response.headers,
 		};
 	}
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useAddPetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useAddPetMutation.ts
@@ -18,7 +18,7 @@ export interface AddPetProps extends Omit<FetcherOptions<unknown, AddPetRequestB
 
 export interface AddPetResponseContainer {
 	content: AddPetOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function addPet(props: AddPetProps): Promise<AddPetResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useAddPetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useAddPetMutation.ts
@@ -18,7 +18,7 @@ export interface AddPetProps extends Omit<FetcherOptions<unknown, AddPetRequestB
 
 export interface AddPetResponseContainer {
 	content: AddPetOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function addPet(props: AddPetProps): Promise<AddPetResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useAddPetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useAddPetMutation.ts
@@ -17,7 +17,7 @@ export interface AddPetProps extends Omit<FetcherOptions<unknown, AddPetRequestB
 }
 
 export interface AddPetResponseContainer {
-	content: AddPetOkResponse;
+	body: AddPetOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useCreateUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useCreateUserMutation.ts
@@ -19,7 +19,7 @@ export interface CreateUserProps
 
 export interface CreateUserResponseContainer {
 	content: CreateUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function createUser(props: CreateUserProps): Promise<CreateUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useCreateUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useCreateUserMutation.ts
@@ -18,7 +18,7 @@ export interface CreateUserProps
 }
 
 export interface CreateUserResponseContainer {
-	content: CreateUserOkResponse;
+	body: CreateUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useCreateUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useCreateUserMutation.ts
@@ -19,7 +19,7 @@ export interface CreateUserProps
 
 export interface CreateUserResponseContainer {
 	content: CreateUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function createUser(props: CreateUserProps): Promise<CreateUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useCreateUsersWithListInputMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useCreateUsersWithListInputMutation.ts
@@ -19,7 +19,7 @@ export interface CreateUsersWithListInputProps
 
 export interface CreateUsersWithListInputResponseContainer {
 	content: CreateUsersWithListInputOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function createUsersWithListInput(

--- a/examples/output/petstore-openapi-v3.0/hooks/useCreateUsersWithListInputMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useCreateUsersWithListInputMutation.ts
@@ -19,7 +19,7 @@ export interface CreateUsersWithListInputProps
 
 export interface CreateUsersWithListInputResponseContainer {
 	content: CreateUsersWithListInputOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function createUsersWithListInput(

--- a/examples/output/petstore-openapi-v3.0/hooks/useCreateUsersWithListInputMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useCreateUsersWithListInputMutation.ts
@@ -18,7 +18,7 @@ export interface CreateUsersWithListInputProps
 }
 
 export interface CreateUsersWithListInputResponseContainer {
-	content: CreateUsersWithListInputOkResponse;
+	body: CreateUsersWithListInputOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeleteOrderMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeleteOrderMutation.ts
@@ -21,7 +21,7 @@ export interface DeleteOrderProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface DeleteOrderResponseContainer {
-	content: DeleteOrderOkResponse;
+	body: DeleteOrderOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeleteOrderMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeleteOrderMutation.ts
@@ -22,7 +22,7 @@ export interface DeleteOrderProps
 
 export interface DeleteOrderResponseContainer {
 	content: DeleteOrderOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function deleteOrder(props: DeleteOrderProps): Promise<DeleteOrderResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeleteOrderMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeleteOrderMutation.ts
@@ -22,7 +22,7 @@ export interface DeleteOrderProps
 
 export interface DeleteOrderResponseContainer {
 	content: DeleteOrderOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function deleteOrder(props: DeleteOrderProps): Promise<DeleteOrderResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
@@ -25,7 +25,7 @@ export interface DeletePetProps
 		Omit<FetcherOptions<unknown, unknown, DeletePetMutationHeaderParams>, 'url'> {}
 
 export interface DeletePetResponseContainer {
-	content: DeletePetOkResponse;
+	body: DeletePetOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
@@ -26,7 +26,7 @@ export interface DeletePetProps
 
 export interface DeletePetResponseContainer {
 	content: DeletePetOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function deletePet(props: DeletePetProps): Promise<DeletePetResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeletePetMutation.ts
@@ -26,7 +26,7 @@ export interface DeletePetProps
 
 export interface DeletePetResponseContainer {
 	content: DeletePetOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function deletePet(props: DeletePetProps): Promise<DeletePetResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeleteUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeleteUserMutation.ts
@@ -18,7 +18,7 @@ export interface DeleteUserProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface DeleteUserResponseContainer {
-	content: DeleteUserOkResponse;
+	body: DeleteUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeleteUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeleteUserMutation.ts
@@ -19,7 +19,7 @@ export interface DeleteUserProps
 
 export interface DeleteUserResponseContainer {
 	content: DeleteUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function deleteUser(props: DeleteUserProps): Promise<DeleteUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useDeleteUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useDeleteUserMutation.ts
@@ -19,7 +19,7 @@ export interface DeleteUserProps
 
 export interface DeleteUserResponseContainer {
 	content: DeleteUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function deleteUser(props: DeleteUserProps): Promise<DeleteUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByStatusQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByStatusQuery.ts
@@ -24,7 +24,7 @@ export interface FindPetsByStatusProps
 
 export interface FindPetsByStatusResponseContainer {
 	content: FindPetsByStatusOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function findPetsByStatus(

--- a/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByStatusQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByStatusQuery.ts
@@ -24,7 +24,7 @@ export interface FindPetsByStatusProps
 
 export interface FindPetsByStatusResponseContainer {
 	content: FindPetsByStatusOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function findPetsByStatus(

--- a/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByStatusQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByStatusQuery.ts
@@ -23,7 +23,7 @@ export interface FindPetsByStatusProps
 }
 
 export interface FindPetsByStatusResponseContainer {
-	content: FindPetsByStatusOkResponse;
+	body: FindPetsByStatusOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByTagsQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByTagsQuery.ts
@@ -20,7 +20,7 @@ export interface FindPetsByTagsProps
 }
 
 export interface FindPetsByTagsResponseContainer {
-	content: FindPetsByTagsOkResponse;
+	body: FindPetsByTagsOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByTagsQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByTagsQuery.ts
@@ -21,7 +21,7 @@ export interface FindPetsByTagsProps
 
 export interface FindPetsByTagsResponseContainer {
 	content: FindPetsByTagsOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function findPetsByTags(

--- a/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByTagsQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useFindPetsByTagsQuery.ts
@@ -21,7 +21,7 @@ export interface FindPetsByTagsProps
 
 export interface FindPetsByTagsResponseContainer {
 	content: FindPetsByTagsOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function findPetsByTags(

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetInventoryQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetInventoryQuery.ts
@@ -13,7 +13,7 @@ export interface GetInventoryProps extends Omit<FetcherOptions<unknown, unknown>
 
 export interface GetInventoryResponseContainer {
 	content: GetInventoryOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function getInventory(props: GetInventoryProps): Promise<GetInventoryResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetInventoryQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetInventoryQuery.ts
@@ -12,7 +12,7 @@ export type GetInventoryErrorResponse = unknown;
 export interface GetInventoryProps extends Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface GetInventoryResponseContainer {
-	content: GetInventoryOkResponse;
+	body: GetInventoryOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetInventoryQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetInventoryQuery.ts
@@ -13,7 +13,7 @@ export interface GetInventoryProps extends Omit<FetcherOptions<unknown, unknown>
 
 export interface GetInventoryResponseContainer {
 	content: GetInventoryOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function getInventory(props: GetInventoryProps): Promise<GetInventoryResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetOrderByIdQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetOrderByIdQuery.ts
@@ -23,7 +23,7 @@ export interface GetOrderByIdProps
 
 export interface GetOrderByIdResponseContainer {
 	content: GetOrderByIdOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function getOrderById(props: GetOrderByIdProps): Promise<GetOrderByIdResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetOrderByIdQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetOrderByIdQuery.ts
@@ -22,7 +22,7 @@ export interface GetOrderByIdProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface GetOrderByIdResponseContainer {
-	content: GetOrderByIdOkResponse;
+	body: GetOrderByIdOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetOrderByIdQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetOrderByIdQuery.ts
@@ -23,7 +23,7 @@ export interface GetOrderByIdProps
 
 export interface GetOrderByIdResponseContainer {
 	content: GetOrderByIdOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function getOrderById(props: GetOrderByIdProps): Promise<GetOrderByIdResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetPetByIdQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetPetByIdQuery.ts
@@ -22,7 +22,7 @@ export interface GetPetByIdProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface GetPetByIdResponseContainer {
-	content: GetPetByIdOkResponse;
+	body: GetPetByIdOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetPetByIdQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetPetByIdQuery.ts
@@ -23,7 +23,7 @@ export interface GetPetByIdProps
 
 export interface GetPetByIdResponseContainer {
 	content: GetPetByIdOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function getPetById(props: GetPetByIdProps): Promise<GetPetByIdResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetPetByIdQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetPetByIdQuery.ts
@@ -23,7 +23,7 @@ export interface GetPetByIdProps
 
 export interface GetPetByIdResponseContainer {
 	content: GetPetByIdOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function getPetById(props: GetPetByIdProps): Promise<GetPetByIdResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetUserByNameQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetUserByNameQuery.ts
@@ -19,7 +19,7 @@ export interface GetUserByNameProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface GetUserByNameResponseContainer {
-	content: GetUserByNameOkResponse;
+	body: GetUserByNameOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetUserByNameQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetUserByNameQuery.ts
@@ -20,7 +20,7 @@ export interface GetUserByNameProps
 
 export interface GetUserByNameResponseContainer {
 	content: GetUserByNameOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function getUserByName(props: GetUserByNameProps): Promise<GetUserByNameResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useGetUserByNameQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useGetUserByNameQuery.ts
@@ -20,7 +20,7 @@ export interface GetUserByNameProps
 
 export interface GetUserByNameResponseContainer {
 	content: GetUserByNameOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function getUserByName(props: GetUserByNameProps): Promise<GetUserByNameResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useLoginUserQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useLoginUserQuery.ts
@@ -21,7 +21,7 @@ export interface LoginUserProps
 
 export interface LoginUserResponseContainer {
 	content: LoginUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function loginUser(props: LoginUserProps): Promise<LoginUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useLoginUserQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useLoginUserQuery.ts
@@ -20,7 +20,7 @@ export interface LoginUserProps
 }
 
 export interface LoginUserResponseContainer {
-	content: LoginUserOkResponse;
+	body: LoginUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useLoginUserQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useLoginUserQuery.ts
@@ -21,7 +21,7 @@ export interface LoginUserProps
 
 export interface LoginUserResponseContainer {
 	content: LoginUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function loginUser(props: LoginUserProps): Promise<LoginUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useLogoutUserQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useLogoutUserQuery.ts
@@ -13,7 +13,7 @@ export interface LogoutUserProps extends Omit<FetcherOptions<unknown, unknown>, 
 
 export interface LogoutUserResponseContainer {
 	content: LogoutUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function logoutUser(props: LogoutUserProps): Promise<LogoutUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useLogoutUserQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useLogoutUserQuery.ts
@@ -12,7 +12,7 @@ export type LogoutUserErrorResponse = unknown;
 export interface LogoutUserProps extends Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface LogoutUserResponseContainer {
-	content: LogoutUserOkResponse;
+	body: LogoutUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useLogoutUserQuery.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useLogoutUserQuery.ts
@@ -13,7 +13,7 @@ export interface LogoutUserProps extends Omit<FetcherOptions<unknown, unknown>, 
 
 export interface LogoutUserResponseContainer {
 	content: LogoutUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function logoutUser(props: LogoutUserProps): Promise<LogoutUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/usePlaceOrderMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/usePlaceOrderMutation.ts
@@ -18,7 +18,7 @@ export interface PlaceOrderProps
 }
 
 export interface PlaceOrderResponseContainer {
-	content: PlaceOrderOkResponse;
+	body: PlaceOrderOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/usePlaceOrderMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/usePlaceOrderMutation.ts
@@ -19,7 +19,7 @@ export interface PlaceOrderProps
 
 export interface PlaceOrderResponseContainer {
 	content: PlaceOrderOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function placeOrder(props: PlaceOrderProps): Promise<PlaceOrderResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/usePlaceOrderMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/usePlaceOrderMutation.ts
@@ -19,7 +19,7 @@ export interface PlaceOrderProps
 
 export interface PlaceOrderResponseContainer {
 	content: PlaceOrderOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function placeOrder(props: PlaceOrderProps): Promise<PlaceOrderResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetMutation.ts
@@ -18,7 +18,7 @@ export interface UpdatePetProps extends Omit<FetcherOptions<unknown, UpdatePetRe
 
 export interface UpdatePetResponseContainer {
 	content: UpdatePetOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function updatePet(props: UpdatePetProps): Promise<UpdatePetResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetMutation.ts
@@ -17,7 +17,7 @@ export interface UpdatePetProps extends Omit<FetcherOptions<unknown, UpdatePetRe
 }
 
 export interface UpdatePetResponseContainer {
-	content: UpdatePetOkResponse;
+	body: UpdatePetOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetMutation.ts
@@ -18,7 +18,7 @@ export interface UpdatePetProps extends Omit<FetcherOptions<unknown, UpdatePetRe
 
 export interface UpdatePetResponseContainer {
 	content: UpdatePetOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function updatePet(props: UpdatePetProps): Promise<UpdatePetResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetWithFormMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetWithFormMutation.ts
@@ -29,7 +29,7 @@ export interface UpdatePetWithFormProps
 
 export interface UpdatePetWithFormResponseContainer {
 	content: UpdatePetWithFormOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function updatePetWithForm(

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetWithFormMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetWithFormMutation.ts
@@ -28,7 +28,7 @@ export interface UpdatePetWithFormProps
 }
 
 export interface UpdatePetWithFormResponseContainer {
-	content: UpdatePetWithFormOkResponse;
+	body: UpdatePetWithFormOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetWithFormMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdatePetWithFormMutation.ts
@@ -29,7 +29,7 @@ export interface UpdatePetWithFormProps
 
 export interface UpdatePetWithFormResponseContainer {
 	content: UpdatePetWithFormOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function updatePetWithForm(

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdateUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdateUserMutation.ts
@@ -24,7 +24,7 @@ export interface UpdateUserProps
 
 export interface UpdateUserResponseContainer {
 	content: UpdateUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function updateUser(props: UpdateUserProps): Promise<UpdateUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdateUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdateUserMutation.ts
@@ -23,7 +23,7 @@ export interface UpdateUserProps
 }
 
 export interface UpdateUserResponseContainer {
-	content: UpdateUserOkResponse;
+	body: UpdateUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useUpdateUserMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUpdateUserMutation.ts
@@ -24,7 +24,7 @@ export interface UpdateUserProps
 
 export interface UpdateUserResponseContainer {
 	content: UpdateUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function updateUser(props: UpdateUserProps): Promise<UpdateUserResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useUploadFileMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUploadFileMutation.ts
@@ -31,7 +31,7 @@ export interface UploadFileProps
 }
 
 export interface UploadFileResponseContainer {
-	content: UploadFileOkResponse;
+	body: UploadFileOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-openapi-v3.0/hooks/useUploadFileMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUploadFileMutation.ts
@@ -32,7 +32,7 @@ export interface UploadFileProps
 
 export interface UploadFileResponseContainer {
 	content: UploadFileOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function uploadFile(props: UploadFileProps): Promise<UploadFileResponseContainer> {

--- a/examples/output/petstore-openapi-v3.0/hooks/useUploadFileMutation.ts
+++ b/examples/output/petstore-openapi-v3.0/hooks/useUploadFileMutation.ts
@@ -32,7 +32,7 @@ export interface UploadFileProps
 
 export interface UploadFileResponseContainer {
 	content: UploadFileOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function uploadFile(props: UploadFileProps): Promise<UploadFileResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/fetcher.ts
+++ b/examples/output/petstore-swagger/hooks/fetcher.ts
@@ -21,7 +21,7 @@ export async function fetcher<
 	THeaderParams = HeadersInit,
 >(
 	options: FetcherOptions<TQueryParams, TBody, THeaderParams>,
-): Promise<ResponseContainer<TResponse, Record<string, any>>> {
+): Promise<ResponseContainer<TResponse, Headers>> {
 	const { body, url, queryParams, headers, ...rest } = options;
 
 	const response = await fetch(url, {
@@ -41,7 +41,7 @@ export async function fetcher<
 	if (response.ok) {
 		return {
 			content: data,
-			headers: {},
+			headers: response.headers,
 		};
 	}
 

--- a/examples/output/petstore-swagger/hooks/fetcher.ts
+++ b/examples/output/petstore-swagger/hooks/fetcher.ts
@@ -10,7 +10,7 @@ export interface FetcherOptions<TQueryParams = never, TBody = never, THeaderPara
 const JSON_HEADERS = ['application/json'];
 
 interface ResponseContainer<TResponse, TResponseHeaders> {
-	content: TResponse;
+	body: TResponse;
 	headers: TResponseHeaders;
 }
 
@@ -40,7 +40,7 @@ export async function fetcher<
 
 	if (response.ok) {
 		return {
-			content: data,
+			body: data,
 			headers: response.headers,
 		};
 	}

--- a/examples/output/petstore-swagger/hooks/useAddPetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useAddPetMutation.ts
@@ -19,7 +19,7 @@ export interface AddPetProps extends Omit<FetcherOptions<unknown, AddPetRequestB
 
 export interface AddPetResponseContainer {
 	content: AddPetOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function addPet(props: AddPetProps): Promise<AddPetResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useAddPetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useAddPetMutation.ts
@@ -19,7 +19,7 @@ export interface AddPetProps extends Omit<FetcherOptions<unknown, AddPetRequestB
 
 export interface AddPetResponseContainer {
 	content: AddPetOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function addPet(props: AddPetProps): Promise<AddPetResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useAddPetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useAddPetMutation.ts
@@ -18,7 +18,7 @@ export interface AddPetProps extends Omit<FetcherOptions<unknown, AddPetRequestB
 }
 
 export interface AddPetResponseContainer {
-	content: AddPetOkResponse;
+	body: AddPetOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useCreateUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUserMutation.ts
@@ -20,7 +20,7 @@ export interface CreateUserProps
 
 export interface CreateUserResponseContainer {
 	content: CreateUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function createUser(props: CreateUserProps): Promise<CreateUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useCreateUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUserMutation.ts
@@ -20,7 +20,7 @@ export interface CreateUserProps
 
 export interface CreateUserResponseContainer {
 	content: CreateUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function createUser(props: CreateUserProps): Promise<CreateUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useCreateUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUserMutation.ts
@@ -19,7 +19,7 @@ export interface CreateUserProps
 }
 
 export interface CreateUserResponseContainer {
-	content: CreateUserOkResponse;
+	body: CreateUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useCreateUsersWithArrayInputMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUsersWithArrayInputMutation.ts
@@ -20,7 +20,7 @@ export interface CreateUsersWithArrayInputProps
 
 export interface CreateUsersWithArrayInputResponseContainer {
 	content: CreateUsersWithArrayInputOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function createUsersWithArrayInput(

--- a/examples/output/petstore-swagger/hooks/useCreateUsersWithArrayInputMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUsersWithArrayInputMutation.ts
@@ -20,7 +20,7 @@ export interface CreateUsersWithArrayInputProps
 
 export interface CreateUsersWithArrayInputResponseContainer {
 	content: CreateUsersWithArrayInputOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function createUsersWithArrayInput(

--- a/examples/output/petstore-swagger/hooks/useCreateUsersWithArrayInputMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUsersWithArrayInputMutation.ts
@@ -19,7 +19,7 @@ export interface CreateUsersWithArrayInputProps
 }
 
 export interface CreateUsersWithArrayInputResponseContainer {
-	content: CreateUsersWithArrayInputOkResponse;
+	body: CreateUsersWithArrayInputOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useCreateUsersWithListInputMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUsersWithListInputMutation.ts
@@ -19,7 +19,7 @@ export interface CreateUsersWithListInputProps
 }
 
 export interface CreateUsersWithListInputResponseContainer {
-	content: CreateUsersWithListInputOkResponse;
+	body: CreateUsersWithListInputOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useCreateUsersWithListInputMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUsersWithListInputMutation.ts
@@ -20,7 +20,7 @@ export interface CreateUsersWithListInputProps
 
 export interface CreateUsersWithListInputResponseContainer {
 	content: CreateUsersWithListInputOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function createUsersWithListInput(

--- a/examples/output/petstore-swagger/hooks/useCreateUsersWithListInputMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useCreateUsersWithListInputMutation.ts
@@ -20,7 +20,7 @@ export interface CreateUsersWithListInputProps
 
 export interface CreateUsersWithListInputResponseContainer {
 	content: CreateUsersWithListInputOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function createUsersWithListInput(

--- a/examples/output/petstore-swagger/hooks/useDeleteOrderMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeleteOrderMutation.ts
@@ -22,7 +22,7 @@ export interface DeleteOrderProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface DeleteOrderResponseContainer {
-	content: DeleteOrderOkResponse;
+	body: DeleteOrderOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useDeleteOrderMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeleteOrderMutation.ts
@@ -23,7 +23,7 @@ export interface DeleteOrderProps
 
 export interface DeleteOrderResponseContainer {
 	content: DeleteOrderOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function deleteOrder(props: DeleteOrderProps): Promise<DeleteOrderResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useDeleteOrderMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeleteOrderMutation.ts
@@ -23,7 +23,7 @@ export interface DeleteOrderProps
 
 export interface DeleteOrderResponseContainer {
 	content: DeleteOrderOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function deleteOrder(props: DeleteOrderProps): Promise<DeleteOrderResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
@@ -27,7 +27,7 @@ export interface DeletePetProps
 
 export interface DeletePetResponseContainer {
 	content: DeletePetOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function deletePet(props: DeletePetProps): Promise<DeletePetResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
@@ -27,7 +27,7 @@ export interface DeletePetProps
 
 export interface DeletePetResponseContainer {
 	content: DeletePetOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function deletePet(props: DeletePetProps): Promise<DeletePetResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeletePetMutation.ts
@@ -26,7 +26,7 @@ export interface DeletePetProps
 		Omit<FetcherOptions<unknown, unknown, DeletePetMutationHeaderParams>, 'url'> {}
 
 export interface DeletePetResponseContainer {
-	content: DeletePetOkResponse;
+	body: DeletePetOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useDeleteUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeleteUserMutation.ts
@@ -20,7 +20,7 @@ export interface DeleteUserProps
 
 export interface DeleteUserResponseContainer {
 	content: DeleteUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function deleteUser(props: DeleteUserProps): Promise<DeleteUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useDeleteUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeleteUserMutation.ts
@@ -19,7 +19,7 @@ export interface DeleteUserProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface DeleteUserResponseContainer {
-	content: DeleteUserOkResponse;
+	body: DeleteUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useDeleteUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useDeleteUserMutation.ts
@@ -20,7 +20,7 @@ export interface DeleteUserProps
 
 export interface DeleteUserResponseContainer {
 	content: DeleteUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function deleteUser(props: DeleteUserProps): Promise<DeleteUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useFindPetsByStatusQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useFindPetsByStatusQuery.ts
@@ -21,7 +21,7 @@ export interface FindPetsByStatusProps
 }
 
 export interface FindPetsByStatusResponseContainer {
-	content: FindPetsByStatusOkResponse;
+	body: FindPetsByStatusOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useFindPetsByStatusQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useFindPetsByStatusQuery.ts
@@ -22,7 +22,7 @@ export interface FindPetsByStatusProps
 
 export interface FindPetsByStatusResponseContainer {
 	content: FindPetsByStatusOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function findPetsByStatus(

--- a/examples/output/petstore-swagger/hooks/useFindPetsByStatusQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useFindPetsByStatusQuery.ts
@@ -22,7 +22,7 @@ export interface FindPetsByStatusProps
 
 export interface FindPetsByStatusResponseContainer {
 	content: FindPetsByStatusOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function findPetsByStatus(

--- a/examples/output/petstore-swagger/hooks/useFindPetsByTagsQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useFindPetsByTagsQuery.ts
@@ -22,7 +22,7 @@ export interface FindPetsByTagsProps
 
 export interface FindPetsByTagsResponseContainer {
 	content: FindPetsByTagsOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function findPetsByTags(

--- a/examples/output/petstore-swagger/hooks/useFindPetsByTagsQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useFindPetsByTagsQuery.ts
@@ -21,7 +21,7 @@ export interface FindPetsByTagsProps
 }
 
 export interface FindPetsByTagsResponseContainer {
-	content: FindPetsByTagsOkResponse;
+	body: FindPetsByTagsOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useFindPetsByTagsQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useFindPetsByTagsQuery.ts
@@ -22,7 +22,7 @@ export interface FindPetsByTagsProps
 
 export interface FindPetsByTagsResponseContainer {
 	content: FindPetsByTagsOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function findPetsByTags(

--- a/examples/output/petstore-swagger/hooks/useGetInventoryQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetInventoryQuery.ts
@@ -14,7 +14,7 @@ export interface GetInventoryProps extends Omit<FetcherOptions<unknown, unknown>
 
 export interface GetInventoryResponseContainer {
 	content: GetInventoryOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function getInventory(props: GetInventoryProps): Promise<GetInventoryResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useGetInventoryQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetInventoryQuery.ts
@@ -14,7 +14,7 @@ export interface GetInventoryProps extends Omit<FetcherOptions<unknown, unknown>
 
 export interface GetInventoryResponseContainer {
 	content: GetInventoryOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function getInventory(props: GetInventoryProps): Promise<GetInventoryResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useGetInventoryQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetInventoryQuery.ts
@@ -13,7 +13,7 @@ export type GetInventoryErrorResponse = unknown;
 export interface GetInventoryProps extends Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface GetInventoryResponseContainer {
-	content: GetInventoryOkResponse;
+	body: GetInventoryOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useGetOrderByIdQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetOrderByIdQuery.ts
@@ -24,7 +24,7 @@ export interface GetOrderByIdProps
 
 export interface GetOrderByIdResponseContainer {
 	content: GetOrderByIdOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function getOrderById(props: GetOrderByIdProps): Promise<GetOrderByIdResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useGetOrderByIdQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetOrderByIdQuery.ts
@@ -23,7 +23,7 @@ export interface GetOrderByIdProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface GetOrderByIdResponseContainer {
-	content: GetOrderByIdOkResponse;
+	body: GetOrderByIdOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useGetOrderByIdQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetOrderByIdQuery.ts
@@ -24,7 +24,7 @@ export interface GetOrderByIdProps
 
 export interface GetOrderByIdResponseContainer {
 	content: GetOrderByIdOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function getOrderById(props: GetOrderByIdProps): Promise<GetOrderByIdResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useGetPetByIdQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetPetByIdQuery.ts
@@ -24,7 +24,7 @@ export interface GetPetByIdProps
 
 export interface GetPetByIdResponseContainer {
 	content: GetPetByIdOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function getPetById(props: GetPetByIdProps): Promise<GetPetByIdResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useGetPetByIdQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetPetByIdQuery.ts
@@ -23,7 +23,7 @@ export interface GetPetByIdProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface GetPetByIdResponseContainer {
-	content: GetPetByIdOkResponse;
+	body: GetPetByIdOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useGetPetByIdQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetPetByIdQuery.ts
@@ -24,7 +24,7 @@ export interface GetPetByIdProps
 
 export interface GetPetByIdResponseContainer {
 	content: GetPetByIdOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function getPetById(props: GetPetByIdProps): Promise<GetPetByIdResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useGetUserByNameQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetUserByNameQuery.ts
@@ -21,7 +21,7 @@ export interface GetUserByNameProps
 
 export interface GetUserByNameResponseContainer {
 	content: GetUserByNameOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function getUserByName(props: GetUserByNameProps): Promise<GetUserByNameResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useGetUserByNameQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetUserByNameQuery.ts
@@ -20,7 +20,7 @@ export interface GetUserByNameProps
 		Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface GetUserByNameResponseContainer {
-	content: GetUserByNameOkResponse;
+	body: GetUserByNameOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useGetUserByNameQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useGetUserByNameQuery.ts
@@ -21,7 +21,7 @@ export interface GetUserByNameProps
 
 export interface GetUserByNameResponseContainer {
 	content: GetUserByNameOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function getUserByName(props: GetUserByNameProps): Promise<GetUserByNameResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useLoginUserQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useLoginUserQuery.ts
@@ -22,7 +22,7 @@ export interface LoginUserProps
 
 export interface LoginUserResponseContainer {
 	content: LoginUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function loginUser(props: LoginUserProps): Promise<LoginUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useLoginUserQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useLoginUserQuery.ts
@@ -21,7 +21,7 @@ export interface LoginUserProps
 }
 
 export interface LoginUserResponseContainer {
-	content: LoginUserOkResponse;
+	body: LoginUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useLoginUserQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useLoginUserQuery.ts
@@ -22,7 +22,7 @@ export interface LoginUserProps
 
 export interface LoginUserResponseContainer {
 	content: LoginUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function loginUser(props: LoginUserProps): Promise<LoginUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useLogoutUserQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useLogoutUserQuery.ts
@@ -14,7 +14,7 @@ export interface LogoutUserProps extends Omit<FetcherOptions<unknown, unknown>, 
 
 export interface LogoutUserResponseContainer {
 	content: LogoutUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function logoutUser(props: LogoutUserProps): Promise<LogoutUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useLogoutUserQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useLogoutUserQuery.ts
@@ -14,7 +14,7 @@ export interface LogoutUserProps extends Omit<FetcherOptions<unknown, unknown>, 
 
 export interface LogoutUserResponseContainer {
 	content: LogoutUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function logoutUser(props: LogoutUserProps): Promise<LogoutUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useLogoutUserQuery.ts
+++ b/examples/output/petstore-swagger/hooks/useLogoutUserQuery.ts
@@ -13,7 +13,7 @@ export type LogoutUserErrorResponse = unknown;
 export interface LogoutUserProps extends Omit<FetcherOptions<unknown, unknown>, 'url'> {}
 
 export interface LogoutUserResponseContainer {
-	content: LogoutUserOkResponse;
+	body: LogoutUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/usePlaceOrderMutation.ts
+++ b/examples/output/petstore-swagger/hooks/usePlaceOrderMutation.ts
@@ -20,7 +20,7 @@ export interface PlaceOrderProps
 
 export interface PlaceOrderResponseContainer {
 	content: PlaceOrderOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function placeOrder(props: PlaceOrderProps): Promise<PlaceOrderResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/usePlaceOrderMutation.ts
+++ b/examples/output/petstore-swagger/hooks/usePlaceOrderMutation.ts
@@ -19,7 +19,7 @@ export interface PlaceOrderProps
 }
 
 export interface PlaceOrderResponseContainer {
-	content: PlaceOrderOkResponse;
+	body: PlaceOrderOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/usePlaceOrderMutation.ts
+++ b/examples/output/petstore-swagger/hooks/usePlaceOrderMutation.ts
@@ -20,7 +20,7 @@ export interface PlaceOrderProps
 
 export interface PlaceOrderResponseContainer {
 	content: PlaceOrderOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function placeOrder(props: PlaceOrderProps): Promise<PlaceOrderResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useUpdatePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdatePetMutation.ts
@@ -18,7 +18,7 @@ export interface UpdatePetProps extends Omit<FetcherOptions<unknown, UpdatePetRe
 }
 
 export interface UpdatePetResponseContainer {
-	content: UpdatePetOkResponse;
+	body: UpdatePetOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useUpdatePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdatePetMutation.ts
@@ -19,7 +19,7 @@ export interface UpdatePetProps extends Omit<FetcherOptions<unknown, UpdatePetRe
 
 export interface UpdatePetResponseContainer {
 	content: UpdatePetOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function updatePet(props: UpdatePetProps): Promise<UpdatePetResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useUpdatePetMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdatePetMutation.ts
@@ -19,7 +19,7 @@ export interface UpdatePetProps extends Omit<FetcherOptions<unknown, UpdatePetRe
 
 export interface UpdatePetResponseContainer {
 	content: UpdatePetOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function updatePet(props: UpdatePetProps): Promise<UpdatePetResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useUpdatePetWithFormMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdatePetWithFormMutation.ts
@@ -26,7 +26,7 @@ export interface UpdatePetWithFormProps
 }
 
 export interface UpdatePetWithFormResponseContainer {
-	content: UpdatePetWithFormOkResponse;
+	body: UpdatePetWithFormOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useUpdatePetWithFormMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdatePetWithFormMutation.ts
@@ -27,7 +27,7 @@ export interface UpdatePetWithFormProps
 
 export interface UpdatePetWithFormResponseContainer {
 	content: UpdatePetWithFormOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function updatePetWithForm(

--- a/examples/output/petstore-swagger/hooks/useUpdatePetWithFormMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdatePetWithFormMutation.ts
@@ -27,7 +27,7 @@ export interface UpdatePetWithFormProps
 
 export interface UpdatePetWithFormResponseContainer {
 	content: UpdatePetWithFormOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function updatePetWithForm(

--- a/examples/output/petstore-swagger/hooks/useUpdateUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdateUserMutation.ts
@@ -24,7 +24,7 @@ export interface UpdateUserProps
 }
 
 export interface UpdateUserResponseContainer {
-	content: UpdateUserOkResponse;
+	body: UpdateUserOkResponse;
 	headers: Headers;
 }
 

--- a/examples/output/petstore-swagger/hooks/useUpdateUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdateUserMutation.ts
@@ -25,7 +25,7 @@ export interface UpdateUserProps
 
 export interface UpdateUserResponseContainer {
 	content: UpdateUserOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function updateUser(props: UpdateUserProps): Promise<UpdateUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useUpdateUserMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUpdateUserMutation.ts
@@ -25,7 +25,7 @@ export interface UpdateUserProps
 
 export interface UpdateUserResponseContainer {
 	content: UpdateUserOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function updateUser(props: UpdateUserProps): Promise<UpdateUserResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useUploadFileMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUploadFileMutation.ts
@@ -28,7 +28,7 @@ export interface UploadFileProps
 
 export interface UploadFileResponseContainer {
 	content: UploadFileOkResponse;
-	headers: Record<string, any>;
+	headers: HeadersInit;
 }
 
 export function uploadFile(props: UploadFileProps): Promise<UploadFileResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useUploadFileMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUploadFileMutation.ts
@@ -28,7 +28,7 @@ export interface UploadFileProps
 
 export interface UploadFileResponseContainer {
 	content: UploadFileOkResponse;
-	headers: HeadersInit;
+	headers: Headers;
 }
 
 export function uploadFile(props: UploadFileProps): Promise<UploadFileResponseContainer> {

--- a/examples/output/petstore-swagger/hooks/useUploadFileMutation.ts
+++ b/examples/output/petstore-swagger/hooks/useUploadFileMutation.ts
@@ -27,7 +27,7 @@ export interface UploadFileProps
 }
 
 export interface UploadFileResponseContainer {
-	content: UploadFileOkResponse;
+	body: UploadFileOkResponse;
 	headers: Headers;
 }
 

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/oats-plugin-react-query",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/oats-plugin-react-query",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/oats-plugin-react-query",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/oats-plugin-react-query",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/packages/plugin-react-query/src/templates/defaultFetcher.liquid
+++ b/packages/plugin-react-query/src/templates/defaultFetcher.liquid
@@ -18,7 +18,7 @@ export async function fetcher<
 	TQueryParams = never,
 	TBody = never,
 	THeaderParams = HeadersInit,
->(options: FetcherOptions<TQueryParams, TBody, THeaderParams>): Promise<ResponseContainer<TResponse, Record<string, any>>> {
+>(options: FetcherOptions<TQueryParams, TBody, THeaderParams>): Promise<ResponseContainer<TResponse, Headers>> {
 	const { body, url, queryParams, headers, ...rest } = options;
 
 	const response = await fetch(url, {
@@ -38,7 +38,7 @@ export async function fetcher<
 	if (response.ok) {
 		return {
 			content: data, 
-			headers: {}
+			headers: response.headers
 		};
 	}
 

--- a/packages/plugin-react-query/src/templates/defaultFetcher.liquid
+++ b/packages/plugin-react-query/src/templates/defaultFetcher.liquid
@@ -9,7 +9,7 @@ export interface FetcherOptions<TQueryParams = never, TBody = never, THeaderPara
 const JSON_HEADERS = ['application/json'];
 
 interface ResponseContainer<TResponse, TResponseHeaders> {
-	content: TResponse;
+	body: TResponse;
 	headers: TResponseHeaders;
 }
 
@@ -37,7 +37,7 @@ export async function fetcher<
 
 	if (response.ok) {
 		return {
-			content: data, 
+			body: data, 
 			headers: response.headers
 		};
 	}

--- a/packages/plugin-react-query/src/templates/reactQueryCommon.liquid
+++ b/packages/plugin-react-query/src/templates/reactQueryCommon.liquid
@@ -40,7 +40,7 @@ Omit<FetcherOptions<
 }
 
 export interface {{typeName}}ResponseContainer {
-  content: {{okResponseName}}
+  body: {{okResponseName}}
   headers: Headers
 }
 

--- a/packages/plugin-react-query/src/templates/reactQueryCommon.liquid
+++ b/packages/plugin-react-query/src/templates/reactQueryCommon.liquid
@@ -41,7 +41,7 @@ Omit<FetcherOptions<
 
 export interface {{typeName}}ResponseContainer {
   content: {{okResponseName}}
-  headers: HeadersInit
+  headers: Headers
 }
 
 export function {{fetcherName}}(props: {{fetcherPropsName}}): Promise<{{typeName}}ResponseContainer> {

--- a/packages/plugin-react-query/src/templates/reactQueryCommon.liquid
+++ b/packages/plugin-react-query/src/templates/reactQueryCommon.liquid
@@ -41,7 +41,7 @@ Omit<FetcherOptions<
 
 export interface {{typeName}}ResponseContainer {
   content: {{okResponseName}}
-  headers: Record<string, any>
+  headers: HeadersInit
 }
 
 export function {{fetcherName}}(props: {{fetcherPropsName}}): Promise<{{typeName}}ResponseContainer> {


### PR DESCRIPTION
### Summary

Fetcher return type now updated to

```ts
export interface {{typeName}}ResponseContainer {
  body: {{okResponseName}}
  headers: Headers
}
```

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

## [Contributor license agreement](https://github.com/harness/oats/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md)
