### PR TITLE
feat: [AH-781]: Support allOf, oneOf keys along with properties key and update join condition for allOf and oneOf

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/oats-cli",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/packages/cli/src/codegen.mts
+++ b/packages/cli/src/codegen.mts
@@ -208,7 +208,7 @@ export function createObject(
 	}
 
 	if (Array.isArray(item.allOf) && item.allOf.length) {
-		const allOfCode: string[] = []
+		const allOfCode: string[] = [];
 		item.allOf.forEach((entry) => {
 			const resolvedValue = resolveValue(entry, originalRef);
 			allOfCode.push(resolvedValue.code);
@@ -219,7 +219,7 @@ export function createObject(
 	}
 
 	if (Array.isArray(item.oneOf) && item.oneOf.length) {
-		const oneOfCode: string[] = []
+		const oneOfCode: string[] = [];
 		item.oneOf.forEach((entry) => {
 			const resolvedValue = resolveValue(entry, originalRef);
 			oneOfCode.push(resolvedValue.code);
@@ -231,9 +231,9 @@ export function createObject(
 
 	if (item.type || has(item, 'properties') || has(item, 'additionalProperties')) {
 		const props = createObjectProperties(item, originalRef, components);
-		code.push(liquid.renderSync(OBJECT_TEMPLATE, { props }))
-		dependencies.push(... props.flatMap((p) => p.dependencies))
-		imports.push(...props.flatMap((p) => p.imports))
+		code.push(liquid.renderSync(OBJECT_TEMPLATE, { props }));
+		dependencies.push(...props.flatMap((p) => p.dependencies));
+		imports.push(...props.flatMap((p) => p.imports));
 	}
 
 	return {


### PR DESCRIPTION
Changes:
1. Support allOf, oneOf keys along with properties key
2. Update join condition for allOf and oneOf

### Summary

For below schema

```
RegistryConfig:
  description: SubConfig specific for Virtual or Upstream Registry
  discriminator:
    mapping:
      UPSTREAM: '#/components/schemas/UpstreamConfig'
      VIRTUAL: '#/components/schemas/VirtualConfig'
    propertyName: type
  oneOf:
  - $ref: '#/components/schemas/VirtualConfig'
  - $ref: '#/components/schemas/UpstreamConfig'
  properties:
    type:
      $ref: '#/components/schemas/RegistryType'
  required:
  - type
  type: object
```
generated output

```
export type RegistryConfig = VirtualConfig & UpstreamConfig;
```

expected output

```
export type RegistryConfig = (VirtualConfig | UpstreamConfig) & {
    type: RegistryType;
};
```

<!-- ✍️ A clear and concise description...-->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

## [Contributor license agreement](https://github.com/harness/oats/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md)
