### PR TITLE
Assume default status to be 200, fix imports generation for params

### DIFF
--- a/.changeset/smart-dingos-kneel.md
+++ b/.changeset/smart-dingos-kneel.md
@@ -1,0 +1,6 @@
+---
+'@harnessio/oats-cli': major
+'@harnessio/oats-plugin-react-query': patch
+---
+
+Assume default status to be 200, fix imports generation for params

--- a/packages/cli/src/codegen.mts
+++ b/packages/cli/src/codegen.mts
@@ -560,7 +560,9 @@ export function getOkResponses(
 	responses: IResponsesObject,
 	originalRef: string,
 ): ICodeWithMetadata {
-	const okResponses = Object.entries(responses).filter(([key]) => key.startsWith('2') || key === 'default');
+	const okResponses = Object.entries(responses).filter(
+		([key]) => key.startsWith('2') || key === 'default',
+	);
 	return getReqResTypes(okResponses, originalRef);
 }
 
@@ -569,8 +571,7 @@ export function getErrorResponses(
 	originalRef: string,
 ): ICodeWithMetadata {
 	const errorResponses = Object.entries(responses).filter(
-		([key]) =>
-			key.startsWith('3') || key.startsWith('4') || key.startsWith('5'),
+		([key]) => key.startsWith('3') || key.startsWith('4') || key.startsWith('5'),
 	);
 	return getReqResTypes(errorResponses, originalRef);
 }

--- a/packages/cli/src/codegen.mts
+++ b/packages/cli/src/codegen.mts
@@ -560,7 +560,7 @@ export function getOkResponses(
 	responses: IResponsesObject,
 	originalRef: string,
 ): ICodeWithMetadata {
-	const okResponses = Object.entries(responses).filter(([key]) => key.startsWith('2'));
+	const okResponses = Object.entries(responses).filter(([key]) => key.startsWith('2') || key === 'default');
 	return getReqResTypes(okResponses, originalRef);
 }
 
@@ -570,7 +570,7 @@ export function getErrorResponses(
 ): ICodeWithMetadata {
 	const errorResponses = Object.entries(responses).filter(
 		([key]) =>
-			key.startsWith('3') || key.startsWith('4') || key.startsWith('5') || key === 'default',
+			key.startsWith('3') || key.startsWith('4') || key.startsWith('5'),
 	);
 	return getReqResTypes(errorResponses, originalRef);
 }

--- a/packages/plugin-react-query/src/generateReactQueryHooks.mts
+++ b/packages/plugin-react-query/src/generateReactQueryHooks.mts
@@ -111,6 +111,10 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 					? liquid.renderSync(OBJECT_TEMPLATE, { props: headerParams })
 					: null;
 
+			queryParams.forEach(queryParam => queryParam.imports.forEach((imp) => imports.add(imp)));
+			pathParams.forEach(pathParam => pathParam.imports.forEach((imp) => imports.add(imp)));
+			headerParams.forEach(headerParam => headerParam.imports.forEach((imp) => imports.add(imp)));
+
 			const templateProps = {
 				hookName,
 				fetcherPropsName,

--- a/packages/plugin-react-query/src/generateReactQueryHooks.mts
+++ b/packages/plugin-react-query/src/generateReactQueryHooks.mts
@@ -111,9 +111,9 @@ export function generateReactQueryHooks(config?: IConfig): IPlugin['generate'] {
 					? liquid.renderSync(OBJECT_TEMPLATE, { props: headerParams })
 					: null;
 
-			queryParams.forEach(queryParam => queryParam.imports.forEach((imp) => imports.add(imp)));
-			pathParams.forEach(pathParam => pathParam.imports.forEach((imp) => imports.add(imp)));
-			headerParams.forEach(headerParam => headerParam.imports.forEach((imp) => imports.add(imp)));
+			queryParams.forEach((queryParam) => queryParam.imports.forEach((imp) => imports.add(imp)));
+			pathParams.forEach((pathParam) => pathParam.imports.forEach((imp) => imports.add(imp)));
+			headerParams.forEach((headerParam) => headerParam.imports.forEach((imp) => imports.add(imp)));
 
 			const templateProps = {
 				hookName,


### PR DESCRIPTION
### Summary

- Breaking change `oats-cli`: Assume "default" status code to map to a success 200 OK Response
- Fix `oats-plugin-react-query`: Add correct imports if queryParams, PathParams or headerParams have complex types 

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

## [Contributor license agreement](https://github.com/harness/oats/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md)
